### PR TITLE
increase test coverage; new acl modeling features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ package main
 import (
 	"fmt"
 	"os"
-	winacl "github.com/kgoins/go-winacl/pkg"
+	"github.com/audibleblink/go-winacl"
 )
 
 func main() {
@@ -19,4 +19,5 @@ func main() {
 ```
 
 ## Credit
+
 This repo was forked from https://github.com/rvazarkar/go-winacl, who did the hard work of figuring out the models and parsers.

--- a/accesscheck.go
+++ b/accesscheck.go
@@ -1,0 +1,367 @@
+package winacl
+
+import (
+	"fmt"
+)
+
+// AccessCheckResult represents the result of an access check operation
+type AccessCheckResult struct {
+	Granted bool           // Whether access was granted
+	Reason  string         // Reason for the decision
+	Ace     *ACE           // The ACE that determined the result, if any
+	Access  uint32         // Access mask that was granted
+	Details []CheckDetails // Detailed reasoning about the check
+}
+
+// CheckDetails provides detailed information about a step in the access check
+type CheckDetails struct {
+	Step        string
+	Description string
+	Outcome     bool
+}
+
+// TokenUser represents a user in a security token
+type TokenUser struct {
+	UserSID SID
+	Groups  []SID
+	Flags   uint32 // Flags that control how groups are used
+}
+
+// NewTokenUser creates a new TokenUser object
+func NewTokenUser(userSID SID, groups []SID) *TokenUser {
+	return &TokenUser{
+		UserSID: userSID,
+		Groups:  groups,
+		Flags:   0,
+	}
+}
+
+// AccessCheckOptions provides configuration for access checks
+type AccessCheckOptions struct {
+	IgnoreObjectType  bool // Skip object type checks for object ACEs
+	CheckIntegrity    bool // Check integrity levels
+	IntegrityPolicy   IntegrityLevelPolicy
+	SubjectIntegrity  IntegrityLevel // Subject's integrity level
+	ObjectIntegrity   IntegrityLevel // Object's integrity level
+	GenericMapping    map[uint32]uint32
+}
+
+// DefaultAccessCheckOptions returns a default set of access check options
+func DefaultAccessCheckOptions() *AccessCheckOptions {
+	return &AccessCheckOptions{
+		IgnoreObjectType: true,
+		CheckIntegrity:   false,
+		IntegrityPolicy:  PolicyNoWriteUp,
+		GenericMapping: map[uint32]uint32{
+			AccessMaskGenericRead:    AccessMaskReadControl,
+			AccessMaskGenericWrite:   AccessMaskWriteDACL | AccessMaskWriteOwner,
+			AccessMaskGenericExecute: AccessMaskSynchronize,
+			AccessMaskGenericAll:     0xFFFFFFFF,
+		},
+	}
+}
+
+// AccessCheck simulates the Windows access check algorithm
+// Returns whether the requested access is granted and additional details
+func AccessCheck(securityDescriptor *NtSecurityDescriptor, token *TokenUser, 
+	desiredAccess uint32, options *AccessCheckOptions) *AccessCheckResult {
+	
+	result := &AccessCheckResult{
+		Granted: false,
+		Reason:  "",
+		Access:  0,
+		Details: make([]CheckDetails, 0),
+	}
+	
+	if options == nil {
+		options = DefaultAccessCheckOptions()
+	}
+	
+	// Map generic access rights if provided
+	mappedAccess := MapGenericAccess(desiredAccess, options.GenericMapping)
+	
+	// Check integrity level policy if enabled
+	if options.CheckIntegrity {
+		integrityCheck := options.SubjectIntegrity.CheckAccess(
+			options.ObjectIntegrity,
+			options.IntegrityPolicy,
+			mappedAccess)
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        "IntegrityLevel",
+			Description: fmt.Sprintf("Checking if integrity level %s can access %s with policy %d",
+				options.SubjectIntegrity, options.ObjectIntegrity, options.IntegrityPolicy),
+			Outcome: integrityCheck,
+		})
+		
+		if !integrityCheck {
+			result.Reason = "Access denied by integrity level policy"
+			return result
+		}
+	}
+	
+	// Check if the requested resource has a DACL
+	if len(securityDescriptor.DACL.Aces) == 0 {
+		// No DACL means full access (Windows rule)
+		result.Granted = true
+		result.Reason = "No DACL present (full access)"
+		result.Access = mappedAccess
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        "EmptyDACL",
+			Description: "No DACL present; full access granted",
+			Outcome:     true,
+		})
+		
+		return result
+	}
+	
+	// Check owner access - owner always has READ_CONTROL and WRITE_DAC rights
+	isOwner := token.UserSID.String() == securityDescriptor.Owner.String()
+	ownerRights := uint32(AccessMaskReadControl | AccessMaskWriteDACL)
+	
+	result.Details = append(result.Details, CheckDetails{
+		Step:        "OwnerCheck",
+		Description: fmt.Sprintf("Checking if user is owner: %v", isOwner),
+		Outcome:     isOwner,
+	})
+	
+	// If only requesting owner rights and user is owner, grant access
+	if isOwner && (mappedAccess & ^ownerRights) == 0 {
+		result.Granted = true
+		result.Reason = "Access granted to owner"
+		result.Access = mappedAccess & ownerRights
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        "OwnerRights",
+			Description: "Access granted based on ownership",
+			Outcome:     true,
+		})
+		
+		return result
+	}
+	
+	// Process ACEs in order (Windows processes ACEs until a match is found)
+	grantedAccess := uint32(0)
+	deniedAccess := uint32(0)
+	
+	// First process deny ACEs
+	for i, ace := range securityDescriptor.DACL.Aces {
+		// Skip non-deny ACEs in the first pass
+		if ace.Header.Type != AceTypeAccessDenied {
+			continue
+		}
+		
+		// Check if this ACE applies to the token
+		applies, reason := aceAppliesToToken(ace, token, options)
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        fmt.Sprintf("DenyACE[%d]", i),
+			Description: fmt.Sprintf("Checking if deny ACE applies: %v - %s", applies, reason),
+			Outcome:     applies,
+		})
+		
+		if applies {
+			// Map the ACE's access mask using the same mapping
+			aceMappedAccess := MapGenericAccess(ace.AccessMask.Raw(), options.GenericMapping)
+			
+			// If any requested access is explicitly denied, deny the entire request
+			// For debugging:
+			// fmt.Printf("ACE denies: 0x%08X (mapped: 0x%08X), requested: 0x%08X\n", 
+			//    ace.AccessMask.Raw(), aceMappedAccess, mappedAccess)
+				
+			if aceMappedAccess & mappedAccess != 0 {
+				result.Reason = fmt.Sprintf("Access explicitly denied by ACE %d", i)
+				deniedAccess |= (aceMappedAccess & mappedAccess)
+				
+				result.Details = append(result.Details, CheckDetails{
+					Step:        fmt.Sprintf("DenyACE[%d]Match", i),
+					Description: fmt.Sprintf("Access denied by ACE - access mask 0x%08X", aceMappedAccess & mappedAccess),
+					Outcome:     false,
+				})
+				
+				// If all requested access is denied, return immediately
+				if deniedAccess == mappedAccess {
+					ace := ace // Copy to avoid issues with loop variable in closures
+					result.Ace = &ace
+					return result
+				}
+			}
+		}
+	}
+	
+	// Then process allow ACEs
+	for i, ace := range securityDescriptor.DACL.Aces {
+		// Skip non-allow ACEs in the second pass
+		if ace.Header.Type != AceTypeAccessAllowed {
+			continue
+		}
+		
+		// Check if this ACE applies to the token
+		applies, reason := aceAppliesToToken(ace, token, options)
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        fmt.Sprintf("AllowACE[%d]", i),
+			Description: fmt.Sprintf("Checking if allow ACE applies: %v - %s", applies, reason),
+			Outcome:     applies,
+		})
+		
+		if applies {
+			// Map the ACE's access mask using the same mapping
+			aceMappedAccess := MapGenericAccess(ace.AccessMask.Raw(), options.GenericMapping)
+			
+			// Mark any explicitly allowed access rights
+			allowedByThisAce := aceMappedAccess & mappedAccess & ^deniedAccess
+			
+			// For debugging:
+			// fmt.Printf("ACE allows: 0x%08X (mapped: 0x%08X), requested: 0x%08X, denied: 0x%08X, allowed: 0x%08X\n", 
+			//    ace.AccessMask.Raw(), aceMappedAccess, mappedAccess, deniedAccess, allowedByThisAce)
+			
+			if allowedByThisAce != 0 {
+				grantedAccess |= allowedByThisAce
+				
+				result.Details = append(result.Details, CheckDetails{
+					Step:        fmt.Sprintf("AllowACE[%d]Match", i),
+					Description: fmt.Sprintf("Access allowed by ACE - access mask 0x%08X", allowedByThisAce),
+					Outcome:     true,
+				})
+				
+				// If all requested access is granted, we can return immediately
+				if (grantedAccess | deniedAccess) == mappedAccess {
+					break
+				}
+			}
+		}
+	}
+	
+	// Determine final access
+	remainingAccess := mappedAccess & ^(grantedAccess | deniedAccess)
+	
+	// For debugging:
+	// fmt.Printf("Final: requested=%08X, granted=%08X, denied=%08X, unmatched=%08X\n",
+	//    mappedAccess, grantedAccess, deniedAccess, remainingAccess)
+	
+	if remainingAccess == 0 && grantedAccess == mappedAccess {
+		// All requested access was granted
+		result.Granted = true
+		result.Reason = "Access granted by ACL"
+		result.Access = grantedAccess
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        "FinalDecision",
+			Description: "All requested access rights were granted",
+			Outcome:     true,
+		})
+	} else {
+		// Some access was not granted
+		result.Granted = false
+		
+		if deniedAccess != 0 {
+			result.Reason = "Some requested access was explicitly denied"
+		} else {
+			result.Reason = "Some requested access was not granted by any ACE"
+		}
+		
+		result.Access = grantedAccess
+		
+		result.Details = append(result.Details, CheckDetails{
+			Step:        "FinalDecision",
+			Description: fmt.Sprintf(
+				"Access partially granted: requested=%08X, granted=%08X, denied=%08X, unmatched=%08X",
+				mappedAccess, grantedAccess, deniedAccess, remainingAccess),
+			Outcome: false,
+		})
+	}
+	
+	return result
+}
+
+// aceAppliesToToken determines if an ACE applies to the given security token
+func aceAppliesToToken(ace ACE, token *TokenUser, options *AccessCheckOptions) (bool, string) {
+	// Get the SID from the ACE
+	var aceSID SID
+	
+	switch oa := ace.ObjectAce.(type) {
+	case BasicAce:
+		aceSID = oa.SecurityIdentifier
+	case AdvancedAce:
+		aceSID = oa.SecurityIdentifier
+		
+		// Check if this is an object ACE and we need to check object types
+		if !options.IgnoreObjectType {
+			// If this is an Object ACE, further checks for object type would be done here
+			// This would involve checking if the requested object's type matches the ACE's object type
+			// For this implementation, we're simplifying by ignoring object types if requested
+		}
+	default:
+		return false, "Unknown ACE object type"
+	}
+	
+	// Check for well-known SIDs
+	aceSIDStr := aceSID.String()
+	
+	// For debugging:
+	// fmt.Printf("Checking ACE SID: %s vs user SID: %s\n", aceSIDStr, token.UserSID.String())
+	// fmt.Printf("User groups: %v\n", token.Groups)
+	
+	// Everyone (S-1-1-0) always matches all tokens
+	if aceSIDStr == "S-1-1-0" {
+		return true, "Everyone SID matches all tokens"
+	}
+	
+	// Check if the SID matches the user directly
+	if aceSIDStr == token.UserSID.String() {
+		return true, "Directly matches user SID"
+	}
+	
+	// Check if the SID matches any of the user's groups
+	for _, group := range token.Groups {
+		groupStr := group.String()
+		// For debugging:
+		// fmt.Printf("  Comparing to group: %s\n", groupStr)
+		if aceSIDStr == groupStr {
+			return true, "Matches a group SID"
+		}
+	}
+	
+	return false, "No SID match found"
+}
+
+// MapGenericAccess maps generic access rights to specific rights
+func MapGenericAccess(access uint32, mapping map[uint32]uint32) uint32 {
+	if mapping == nil {
+		return access
+	}
+	
+	result := uint32(0)
+	
+	// Check each generic right
+	genericRights := []uint32{
+		AccessMaskGenericRead,
+		AccessMaskGenericWrite,
+		AccessMaskGenericExecute,
+		AccessMaskGenericAll,
+	}
+	
+	// Map any generic rights present in the access mask
+	for _, genericRight := range genericRights {
+		if access&genericRight != 0 {
+			if specificRights, ok := mapping[genericRight]; ok {
+				result |= specificRights
+				// Remove the generic right bit
+				access &= ^genericRight
+			}
+		}
+	}
+	
+	// Add any remaining specific rights
+	result |= access
+	
+	// If we're mapping a generic right but there's no specific mapping,
+	// keep the generic right as-is to allow direct comparisons
+	if result == 0 && access != 0 {
+		return access
+	}
+	
+	return result
+}

--- a/accesscheck_test.go
+++ b/accesscheck_test.go
@@ -1,0 +1,652 @@
+package winacl
+
+import (
+	"testing"
+)
+
+func TestAccessCheck(t *testing.T) {
+	// Create a set of common SIDs for testing
+	adminSID, _ := NewSIDFromString("S-1-5-32-544") // Administrators
+	userSID, _ := NewSIDFromString("S-1-5-21-1234567890-1234567890-1234567890-1001") // Regular user
+	systemSID, _ := NewSIDFromString("S-1-5-18") // System
+	everyoneSID, _ := NewSIDFromString("S-1-1-0") // Everyone
+
+	// Test case 1: Empty DACL - Full access
+	t.Run("EmptyDACL", func(t *testing.T) {
+		// Create a security descriptor with an empty DACL
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL:  ACL{},
+		}
+
+		// Create a token for a regular user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Request read access
+		result := AccessCheck(sd, token, AccessMaskGenericRead, nil)
+
+		// Empty DACL should grant full access
+		if !result.Granted {
+			t.Errorf("Empty DACL should grant access, but got: %s", result.Reason)
+		}
+	})
+
+	// Test case 2: Owner access rights
+	t.Run("OwnerAccess", func(t *testing.T) {
+		// Create a security descriptor with a DACL that has no ACEs for the user
+		sd := &NtSecurityDescriptor{
+			Owner: userSID, // User is the owner
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{
+					// No ACEs that would grant access to the user
+				},
+			},
+		}
+
+		// Create a token for the user (who is the owner)
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Request owner-specific rights
+		result := AccessCheck(sd, token, AccessMaskReadControl|AccessMaskWriteDACL, nil)
+
+		// Owner should have these rights
+		if !result.Granted {
+			t.Errorf("Owner should have read control and write DACL rights, but got: %s", result.Reason)
+		}
+	})
+
+	// Test case 3: Explicit allow ACE
+	t.Run("ExplicitAllow", func(t *testing.T) {
+		// Create an ACE that allows read access to everyone
+		allowAce := NewAccessAllowedACE(everyoneSID, AccessMaskGenericRead)
+
+		// Create a security descriptor with a DACL containing the allow ACE
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a regular user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Request read access
+		result := AccessCheck(sd, token, AccessMaskGenericRead, nil)
+
+		// Access should be granted
+		if !result.Granted {
+			t.Errorf("Access should be granted via allow ACE, but got: %s", result.Reason)
+		}
+	})
+
+	// Test case 4: Explicit deny ACE
+	t.Run("ExplicitDeny", func(t *testing.T) {
+		// Create an ACE that denies write access to everyone
+		denyAce := NewAccessDeniedACE(everyoneSID, AccessMaskGenericWrite)
+		
+		// Create an ACE that allows read access to everyone
+		allowAce := NewAccessAllowedACE(everyoneSID, AccessMaskGenericRead)
+
+		// Create a security descriptor with a DACL containing both ACEs
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{denyAce, allowAce},
+			},
+		}
+
+		// Create a token for a regular user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Request write access
+		result := AccessCheck(sd, token, AccessMaskGenericWrite, nil)
+
+		// Access should be denied
+		if result.Granted {
+			t.Errorf("Access should be denied via deny ACE, but was granted")
+		}
+
+		// Request read access
+		result = AccessCheck(sd, token, AccessMaskGenericRead, nil)
+
+		// Access should be granted
+		if !result.Granted {
+			t.Errorf("Read access should be granted, but got: %s", result.Reason)
+		}
+	})
+
+	// Test case 5: Deny ACE takes precedence over allow ACE
+	t.Run("DenyTakesPrecedence", func(t *testing.T) {
+		// Create an ACE that allows all access to the user
+		allowAce := NewAccessAllowedACE(userSID, AccessMaskGenericAll)
+		
+		// Create an ACE that denies write access to everyone
+		denyAce := NewAccessDeniedACE(everyoneSID, AccessMaskGenericWrite)
+
+		// Create a security descriptor with a DACL containing both ACEs
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{denyAce, allowAce},
+			},
+		}
+
+		// Create a token for the user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Request write access
+		result := AccessCheck(sd, token, AccessMaskGenericWrite, nil)
+
+		// Access should be denied, despite the allow ACE
+		if result.Granted {
+			t.Errorf("Access should be denied, deny ACE should take precedence, but was granted")
+		}
+	})
+
+	// Test case 6: No matching ACE for the requested access
+	t.Run("NoMatchingACE", func(t *testing.T) {
+		// Create an ACE that allows read access
+		allowAce := NewAccessAllowedACE(everyoneSID, AccessMaskGenericRead)
+
+		// Create a security descriptor with a DACL containing the allow ACE
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a regular user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Request write access (which is not granted by any ACE)
+		result := AccessCheck(sd, token, AccessMaskGenericWrite, nil)
+
+		// Access should be denied
+		if result.Granted {
+			t.Errorf("Access should be denied when no ACE grants the requested access, but was granted")
+		}
+	})
+
+	// Test case 7: Group membership
+	t.Run("GroupMembership", func(t *testing.T) {
+		// Create an ACE that allows read access to administrators
+		allowAce := NewAccessAllowedACE(adminSID, AccessMaskGenericRead)
+
+		// Create a security descriptor with a DACL containing the allow ACE
+		sd := &NtSecurityDescriptor{
+			Owner: systemSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a user who is a member of the administrators group
+		token := NewTokenUser(userSID, []SID{everyoneSID, adminSID})
+
+		// Request read access
+		result := AccessCheck(sd, token, AccessMaskGenericRead, nil)
+
+		// Access should be granted due to group membership
+		if !result.Granted {
+			t.Errorf("Access should be granted via group membership, but got: %s", result.Reason)
+		}
+	})
+
+	// Test case 8: Integrity level policy enforcement
+	t.Run("IntegrityPolicy", func(t *testing.T) {
+		// Create a security descriptor with an allow ACE for everyone that explicitly grants
+		// both generic and specific rights to ensure proper mapping
+		allowAce := NewAccessAllowedACE(
+			everyoneSID, 
+			AccessMaskGenericAll | AccessMaskReadControl | AccessMaskWriteDACL | 
+			AccessMaskGenericRead | AccessMaskGenericWrite)
+		
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a low integrity user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Create options that enforce integrity level checks with explicit mapping
+		options := &AccessCheckOptions{
+			CheckIntegrity:   true,
+			IntegrityPolicy:  PolicyNoWriteUp,
+			SubjectIntegrity: IntegrityLevelLow,
+			ObjectIntegrity:  IntegrityLevelHigh,
+			GenericMapping: map[uint32]uint32{
+				AccessMaskGenericRead:    AccessMaskReadControl,
+				AccessMaskGenericWrite:   AccessMaskWriteDACL,
+				AccessMaskGenericExecute: AccessMaskSynchronize,
+				AccessMaskGenericAll:     0xFFFFFFFF,
+			},
+		}
+
+		// Request write access (should be denied by integrity policy)
+		result := AccessCheck(sd, token, AccessMaskGenericWrite, options)
+
+		// Access should be denied due to integrity policy
+		if result.Granted {
+			t.Errorf("Write access should be denied by integrity policy, but was granted")
+		}
+
+		// Request read access (should be allowed despite integrity level difference)
+		result = AccessCheck(sd, token, AccessMaskGenericRead, options)
+
+		// Read access should be granted
+		if !result.Granted {
+			t.Errorf("Read access should be granted despite integrity level difference, but got: %s", result.Reason)
+		}
+
+		// Now use a stricter policy that prevents read-up
+		options.IntegrityPolicy = PolicyNoReadUp
+
+		// Request read access again (should now be denied)
+		result = AccessCheck(sd, token, AccessMaskGenericRead, options)
+
+		// Access should be denied due to the stricter policy
+		if result.Granted {
+			t.Errorf("Read access should be denied by NoReadUp policy, but was granted")
+		}
+	})
+
+	// Test case 9: Generic access mapping
+	t.Run("GenericAccessMapping", func(t *testing.T) {
+		// Create an ACE that allows specific rights (not generic)
+		specificRights := uint32(AccessMaskReadControl | AccessMaskSynchronize)
+		allowAce := NewAccessAllowedACE(everyoneSID, specificRights)
+		
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a regular user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Create custom mapping
+		options := &AccessCheckOptions{
+			GenericMapping: map[uint32]uint32{
+				AccessMaskGenericRead: AccessMaskReadControl,
+				AccessMaskGenericExecute: AccessMaskSynchronize,
+			},
+		}
+
+		// Request generic read (should map to read control, which is granted)
+		result := AccessCheck(sd, token, AccessMaskGenericRead, options)
+
+		// Access should be granted after mapping
+		if !result.Granted {
+			t.Errorf("Access should be granted after generic mapping, but got: %s", result.Reason)
+		}
+
+		// Request generic write (should map to write DACL, which is not granted)
+		result = AccessCheck(sd, token, AccessMaskGenericWrite, options)
+
+		// Access should be denied
+		if result.Granted {
+			t.Errorf("Write access should be denied after generic mapping, but was granted")
+		}
+	})
+
+	// Test case 10: Partially granted access
+	t.Run("PartialAccess", func(t *testing.T) {
+		// Create an ACE that allows only read access
+		allowAce := NewAccessAllowedACE(everyoneSID, AccessMaskGenericRead | AccessMaskReadControl)
+		
+		sd := &NtSecurityDescriptor{
+			Owner: adminSID,
+			Group: adminSID,
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a regular user
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+
+		// Create mapping options
+		options := &AccessCheckOptions{
+			GenericMapping: map[uint32]uint32{
+				AccessMaskGenericRead:    AccessMaskReadControl,
+				AccessMaskGenericWrite:   AccessMaskWriteDACL,
+				AccessMaskGenericExecute: AccessMaskSynchronize,
+				AccessMaskGenericAll:     0xFFFFFFFF,
+			},
+		}
+
+		// Request both read and write access
+		result := AccessCheck(sd, token, AccessMaskGenericRead|AccessMaskGenericWrite, options)
+
+		// Overall access should be denied because not all requested access was granted
+		if result.Granted {
+			t.Errorf("Access should be partially denied, but was fully granted")
+		}
+
+		// Check that read control (mapped from generic read) was granted
+		if result.Access&AccessMaskReadControl == 0 {
+			t.Errorf("Read control access should be granted within partial access")
+		}
+
+		// The write control (mapped from generic write) should be denied
+		if result.Access&AccessMaskWriteDACL != 0 {
+			t.Errorf("Write DACL access should be denied within partial access")
+		}
+	})
+}
+
+func TestMapGenericAccess(t *testing.T) {
+	// Test case 1: Basic mapping
+	t.Run("BasicMapping", func(t *testing.T) {
+		mapping := map[uint32]uint32{
+			AccessMaskGenericRead:    AccessMaskReadControl,
+			AccessMaskGenericWrite:   AccessMaskWriteDACL,
+			AccessMaskGenericExecute: AccessMaskSynchronize,
+			AccessMaskGenericAll:     0xFFFF,
+		}
+
+		result := MapGenericAccess(AccessMaskGenericRead, mapping)
+		if result != AccessMaskReadControl {
+			t.Errorf("Expected generic read to map to read control, got: 0x%08X", result)
+		}
+	})
+
+	// Test case 2: Combined generic and specific rights
+	t.Run("CombinedRights", func(t *testing.T) {
+		mapping := map[uint32]uint32{
+			AccessMaskGenericRead:  AccessMaskReadControl,
+			AccessMaskGenericWrite: AccessMaskWriteDACL,
+		}
+
+		// Both generic and specific rights
+		combined := uint32(AccessMaskGenericRead | AccessMaskDelete)
+		result := MapGenericAccess(combined, mapping)
+		
+		// Should map generic read to read control and preserve delete
+		expected := uint32(AccessMaskReadControl | AccessMaskDelete)
+		if result != expected {
+			t.Errorf("Expected 0x%08X, got: 0x%08X", expected, result)
+		}
+	})
+
+	// Test case 3: Multiple generic rights
+	t.Run("MultipleGenericRights", func(t *testing.T) {
+		mapping := map[uint32]uint32{
+			AccessMaskGenericRead:    AccessMaskReadControl,
+			AccessMaskGenericWrite:   AccessMaskWriteDACL,
+			AccessMaskGenericExecute: AccessMaskSynchronize,
+		}
+
+		// Multiple generic rights
+		multiple := uint32(AccessMaskGenericRead | AccessMaskGenericWrite)
+		result := MapGenericAccess(multiple, mapping)
+		
+		// Should map both generics to their specific rights
+		expected := uint32(AccessMaskReadControl | AccessMaskWriteDACL)
+		if result != expected {
+			t.Errorf("Expected 0x%08X, got: 0x%08X", expected, result)
+		}
+	})
+
+	// Test case 4: Nil mapping
+	t.Run("NilMapping", func(t *testing.T) {
+		// Passing nil should return the input unchanged
+		access := uint32(AccessMaskGenericRead | AccessMaskDelete)
+		result := MapGenericAccess(access, nil)
+		
+		if result != access {
+			t.Errorf("Expected unchanged access mask with nil mapping")
+		}
+	})
+
+	// Test case 5: Empty mapping
+	t.Run("EmptyMapping", func(t *testing.T) {
+		// Empty mapping should handle generic rights that aren't in the map
+		mapping := map[uint32]uint32{}
+		access := uint32(AccessMaskGenericRead | AccessMaskDelete)
+		result := MapGenericAccess(access, mapping)
+		
+		// Should leave generic read intact and preserve delete
+		if result != access {
+			t.Errorf("Expected unchanged access mask with empty mapping")
+		}
+	})
+}
+
+func TestAceAppliesToToken(t *testing.T) {
+	// Create a set of common SIDs for testing
+	adminSID, _ := NewSIDFromString("S-1-5-32-544") // Administrators
+	userSID, _ := NewSIDFromString("S-1-5-21-1234567890-1234567890-1234567890-1001") // Regular user
+	everyoneSID, _ := NewSIDFromString("S-1-1-0") // Everyone
+
+	// Test case 1: Everyone SID should match any token
+	t.Run("EveryoneMatches", func(t *testing.T) {
+		ace := NewAccessAllowedACE(everyoneSID, AccessMaskGenericRead)
+		token := NewTokenUser(userSID, []SID{})
+		options := DefaultAccessCheckOptions()
+
+		applies, _ := aceAppliesToToken(ace, token, options)
+		if !applies {
+			t.Errorf("Everyone SID should match any token")
+		}
+	})
+
+	// Test case 2: User SID match
+	t.Run("UserSIDMatch", func(t *testing.T) {
+		ace := NewAccessAllowedACE(userSID, AccessMaskGenericRead)
+		token := NewTokenUser(userSID, []SID{adminSID})
+		options := DefaultAccessCheckOptions()
+
+		applies, _ := aceAppliesToToken(ace, token, options)
+		if !applies {
+			t.Errorf("User SID should match the token's user SID")
+		}
+	})
+
+	// Test case 3: Group SID match
+	t.Run("GroupSIDMatch", func(t *testing.T) {
+		ace := NewAccessAllowedACE(adminSID, AccessMaskGenericRead)
+		token := NewTokenUser(userSID, []SID{adminSID})
+		options := DefaultAccessCheckOptions()
+
+		applies, _ := aceAppliesToToken(ace, token, options)
+		if !applies {
+			t.Errorf("Group SID should match one of the token's group SIDs")
+		}
+	})
+
+	// Test case 4: No match
+	t.Run("NoMatch", func(t *testing.T) {
+		ace := NewAccessAllowedACE(adminSID, AccessMaskGenericRead)
+		token := NewTokenUser(userSID, []SID{everyoneSID})
+		options := DefaultAccessCheckOptions()
+
+		applies, _ := aceAppliesToToken(ace, token, options)
+		if applies {
+			t.Errorf("ACE should not apply to token with no matching SIDs")
+		}
+	})
+}
+
+func TestIntegrityLevelCheck(t *testing.T) {
+	// Test case 1: Higher integrity should access lower integrity
+	t.Run("HigherToLower", func(t *testing.T) {
+		// Create a security descriptor with an allow ACE for everyone with explicit access masks
+		allowAce := NewAccessAllowedACE(
+			NewSIDFromStringOrPanic("S-1-1-0"), 
+			AccessMaskGenericAll | AccessMaskGenericWrite | AccessMaskGenericRead | 
+			AccessMaskWriteDACL | AccessMaskReadControl | AccessMaskDelete | 0xFFFF)
+		
+		sd := &NtSecurityDescriptor{
+			Owner: NewSIDFromStringOrPanic("S-1-5-18"), // System
+			Group: NewSIDFromStringOrPanic("S-1-5-32-544"), // Administrators
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a high integrity user accessing a medium integrity object
+		token := NewTokenUser(
+			NewSIDFromStringOrPanic("S-1-5-21-1234567890-1234567890-1234567890-1001"),
+			[]SID{NewSIDFromStringOrPanic("S-1-1-0")}, // Everyone
+		)
+
+		options := &AccessCheckOptions{
+			CheckIntegrity:   true,
+			IntegrityPolicy:  PolicyNoWriteUp,
+			SubjectIntegrity: IntegrityLevelHigh,
+			ObjectIntegrity:  IntegrityLevelMedium,
+			GenericMapping: map[uint32]uint32{
+				AccessMaskGenericRead:    AccessMaskReadControl,
+				AccessMaskGenericWrite:   AccessMaskWriteDACL,
+				AccessMaskGenericExecute: AccessMaskSynchronize,
+				AccessMaskGenericAll:     0xFFFFFFFF,
+			},
+		}
+
+		result := AccessCheck(sd, token, AccessMaskGenericWrite, options)
+
+		// Access should be granted because higher integrity can access lower
+		if !result.Granted {
+			t.Errorf("Higher integrity should be able to write to lower integrity, but got: %s", result.Reason)
+		}
+	})
+
+	// Test case 2: Lower integrity should not write up
+	t.Run("LowerToHigherWriteBlocked", func(t *testing.T) {
+		// Create a security descriptor with an allow ACE for everyone with explicit access masks
+		allowAce := NewAccessAllowedACE(
+			NewSIDFromStringOrPanic("S-1-1-0"), 
+			AccessMaskGenericAll | AccessMaskGenericWrite | AccessMaskGenericRead | 
+			AccessMaskWriteDACL | AccessMaskReadControl | AccessMaskDelete | 0xFFFF)
+		
+		sd := &NtSecurityDescriptor{
+			Owner: NewSIDFromStringOrPanic("S-1-5-18"), // System
+			Group: NewSIDFromStringOrPanic("S-1-5-32-544"), // Administrators
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a low integrity user accessing a high integrity object
+		token := NewTokenUser(
+			NewSIDFromStringOrPanic("S-1-5-21-1234567890-1234567890-1234567890-1001"),
+			[]SID{NewSIDFromStringOrPanic("S-1-1-0")}, // Everyone
+		)
+
+		options := &AccessCheckOptions{
+			CheckIntegrity:   true,
+			IntegrityPolicy:  PolicyNoWriteUp,
+			SubjectIntegrity: IntegrityLevelLow,
+			ObjectIntegrity:  IntegrityLevelHigh,
+			GenericMapping: map[uint32]uint32{
+				AccessMaskGenericRead:    AccessMaskReadControl,
+				AccessMaskGenericWrite:   AccessMaskWriteDACL,
+				AccessMaskGenericExecute: AccessMaskSynchronize,
+				AccessMaskGenericAll:     0xFFFFFFFF,
+			},
+		}
+
+		result := AccessCheck(sd, token, AccessMaskGenericWrite, options)
+
+		// Write access should be denied due to integrity policy
+		if result.Granted {
+			t.Errorf("Low integrity should not be able to write to high integrity")
+		}
+	})
+
+	// Test case 3: Same integrity level should pass
+	t.Run("SameIntegrityLevel", func(t *testing.T) {
+		// Create a security descriptor with an allow ACE for everyone with explicit access masks
+		allowAce := NewAccessAllowedACE(
+			NewSIDFromStringOrPanic("S-1-1-0"), 
+			AccessMaskGenericAll | AccessMaskGenericWrite | AccessMaskGenericRead | 
+			AccessMaskWriteDACL | AccessMaskReadControl | AccessMaskDelete | 0xFFFF)
+		
+		sd := &NtSecurityDescriptor{
+			Owner: NewSIDFromStringOrPanic("S-1-5-18"), // System
+			Group: NewSIDFromStringOrPanic("S-1-5-32-544"), // Administrators
+			DACL: ACL{
+				Aces: []ACE{allowAce},
+			},
+		}
+
+		// Create a token for a medium integrity user accessing a medium integrity object
+		token := NewTokenUser(
+			NewSIDFromStringOrPanic("S-1-5-21-1234567890-1234567890-1234567890-1001"),
+			[]SID{NewSIDFromStringOrPanic("S-1-1-0")}, // Everyone
+		)
+
+		options := &AccessCheckOptions{
+			CheckIntegrity:   true,
+			IntegrityPolicy:  PolicyNoWriteUp | PolicyNoReadUp | PolicyNoExecuteUp,
+			SubjectIntegrity: IntegrityLevelMedium,
+			ObjectIntegrity:  IntegrityLevelMedium,
+			GenericMapping: map[uint32]uint32{
+				AccessMaskGenericRead:    AccessMaskReadControl,
+				AccessMaskGenericWrite:   AccessMaskWriteDACL,
+				AccessMaskGenericExecute: AccessMaskSynchronize,
+				AccessMaskGenericAll:     0xFFFFFFFF,
+			},
+		}
+
+		result := AccessCheck(sd, token, AccessMaskGenericAll, options)
+
+		// Access should be granted at same integrity level regardless of policy
+		if !result.Granted {
+			t.Errorf("Same integrity level should be able to access each other, but got: %s", result.Reason)
+		}
+	})
+}
+
+// Helper function to create a panic-free SID from string
+func NewSIDFromStringOrPanic(sidString string) SID {
+	sid, err := NewSIDFromString(sidString)
+	if err != nil {
+		panic(err)
+	}
+	return sid
+}
+
+// Helper functions for creating ACEs more easily
+func NewAccessAllowedACE(sid SID, value uint32) ACE {
+	return ACE{
+		Header: ACEHeader{
+			Type: AceTypeAccessAllowed,
+			Size: 8 + uint16(8 + 4*int(sid.NumAuthorities)), // Header + access mask + SID size
+		},
+		AccessMask: ACEAccessMask{Value: value},
+		ObjectAce: BasicAce{
+			SecurityIdentifier: sid,
+		},
+	}
+}
+
+func NewAccessDeniedACE(sid SID, value uint32) ACE {
+	return ACE{
+		Header: ACEHeader{
+			Type: AceTypeAccessDenied,
+			Size: 8 + uint16(8 + 4*int(sid.NumAuthorities)), // Header + access mask + SID size
+		},
+		AccessMask: ACEAccessMask{Value: value},
+		ObjectAce: BasicAce{
+			SecurityIdentifier: sid,
+		},
+	}
+}

--- a/ace.go
+++ b/ace.go
@@ -11,6 +11,7 @@ import (
 // https://docs.microsoft.com/en-us/windows/win32/secauthz/access-control-entries
 type AceType byte
 
+// ACE type constants
 const (
 	AceTypeAccessAllowed AceType = iota
 	AceTypeAccessDenied
@@ -31,7 +32,7 @@ const (
 	AceTypeSystemAlarmCallbackObject
 )
 
-// ACETypeLookup maps AceTypes to a human-readable labels
+// ACETypeLookup maps ACE types to human-readable strings
 var ACETypeLookup = map[AceType]string{
 	AceTypeAccessAllowed:               "ACCESS_ALLOWED",
 	AceTypeAccessDenied:                "ACCESS_DENIED",
@@ -52,9 +53,10 @@ var ACETypeLookup = map[AceType]string{
 	AceTypeSystemAlarmCallbackObject:   "SYSTEM_ALARM_CALLBACK_OBJECT",
 }
 
-// AceHeadFlags is a type representing an ACEs header
+// ACEHeaderFlags represents the flags in an ACE header
 type ACEHeaderFlags byte
 
+// ACE header flag constants
 const (
 	ACEHeaderFlagsObjectInheritAce        ACEHeaderFlags = 0x01
 	ACEHeaderFlagsContainerInheritAce                    = 0x02
@@ -65,6 +67,7 @@ const (
 	ACEHeaderFlagsFailedAccessAceFlag                    = 0x80
 )
 
+// ACEHeaderFlagLookup maps ACE header flags to human-readable strings
 var ACEHeaderFlagLookup = map[ACEHeaderFlags]string{
 	ACEHeaderFlagsObjectInheritAce:        "OBJECT_INHERIT_ACE",
 	ACEHeaderFlagsContainerInheritAce:     "CONTAINER_INHERIT_ACE",
@@ -91,9 +94,10 @@ var ACEInheritanceFlagsLookup = map[ACEInheritanceFlags]string{
 
 // ACEAccessMask represents an ACE's permissions
 type ACEAccessMask struct {
-	value uint32
+	Value uint32 // Changed from 'value' to 'Value' to make it exported
 }
 
+// Access mask constants for permissions
 const (
 	AccessMaskGenericRead    = 0x80000000
 	AccessMaskGenericWrite   = 0x40000000
@@ -119,7 +123,7 @@ const (
 	ADSRightDSCreateChild   = 0x00000001
 )
 
-// ACEAccessMaskLookup maps ACEAccessMasks to a human-readable labels
+// ACEAccessMaskLookup maps access masks to human-readable strings
 var ACEAccessMaskLookup = map[uint32]string{
 	AccessMaskGenericRead:    "GENERIC_READ",
 	AccessMaskGenericWrite:   "GENERIC_WRITE",
@@ -144,7 +148,7 @@ var ACEAccessMaskLookup = map[uint32]string{
 
 // Raw returns an ACEAccessMask's uint32 Access Mask
 func (am ACEAccessMask) Raw() uint32 {
-	return am.value
+	return am.Value // Updated to use the exported field name
 }
 
 // String returns an ACEAccessMask's human-readable Access Mask
@@ -157,7 +161,7 @@ func (am ACEAccessMask) String() string {
 // except as a slice of string
 func (am ACEAccessMask) StringSlice() []string {
 	var readableRights []string
-	rights, _ := bamflags.ParseInt(int64(am.value))
+	rights, _ := bamflags.ParseInt(int64(am.Value))
 
 	for _, right := range rights {
 		if perm := ACEAccessMaskLookup[uint32(right)]; perm != "" {
@@ -167,7 +171,7 @@ func (am ACEAccessMask) StringSlice() []string {
 	return readableRights
 }
 
-// ACE represents an ACE within an ACL
+// ACE represents an Access Control Entry
 type ACE struct {
 	//Header + AccessMask is 16 bytes
 	Header     ACEHeader
@@ -253,7 +257,7 @@ func (s BasicAce) GetPrincipal() SID {
 	return s.SecurityIdentifier
 }
 
-//AdvancedAce represents an Object Ace
+// AdvancedAce represents an Object Ace
 type AdvancedAce struct {
 	Flags               ACEInheritanceFlags //4 bytes
 	ObjectType          GUID                //16 bytes

--- a/ace_test.go
+++ b/ace_test.go
@@ -5,25 +5,251 @@ import (
 	"encoding/binary"
 	"testing"
 
-	winacl "github.com/kgoins/go-winacl/pkg"
+	"github.com/audibleblink/go-winacl"
+
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewACEHeader(t *testing.T) {
-
+func TestACEAccessMaskMethods(t *testing.T) {
 	r := require.New(t)
 
-	t.Run("Returns an error when given a malformed byte stream", func(t *testing.T) {
-		sd := newTestSD()
-		ace := sd.DACL.Aces[0]
+	// Create an access mask with specific permissions
+	acm := winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead | winacl.AccessMaskReadControl}
+
+	t.Run("Raw returns the correct value", func(t *testing.T) {
+		value := acm.Raw()
+		r.Equal(uint32(winacl.AccessMaskGenericRead|winacl.AccessMaskReadControl), value)
+	})
+
+	t.Run("String returns a space-separated list of permissions", func(t *testing.T) {
+		s := acm.String()
+		r.Contains(s, "GENERIC_READ")
+		r.Contains(s, "READ_CONTROL")
+	})
+
+	t.Run("StringSlice returns a slice of permission strings", func(t *testing.T) {
+		perms := acm.StringSlice()
+		r.Contains(perms, "GENERIC_READ")
+		r.Contains(perms, "READ_CONTROL")
+		r.Len(perms, 2)
+	})
+}
+
+func TestACEMethods(t *testing.T) {
+	r := require.New(t)
+	
+	t.Run("GetType returns the correct ACE type", func(t *testing.T) {
+		// Create a basic ACE
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowed,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+			Size:  20,
+		}
+		
+		accessMask := winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead}
+		
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 1,
+			Authority:      []byte{0, 0, 0, 0, 0, 5},
+			SubAuthorities: []uint32{18},
+		}
+		
+		basicAce := winacl.BasicAce{SecurityIdentifier: sid}
+		
+		ace := winacl.ACE{
+			Header:     header,
+			AccessMask: accessMask,
+			ObjectAce:  basicAce,
+		}
+		
+		acetype := ace.GetType()
+		r.Equal(winacl.AceTypeAccessAllowed, acetype)
+	})
+
+	t.Run("GetTypeString returns a string representation of type", func(t *testing.T) {
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowed,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+		}
+		
+		ace := winacl.ACE{
+			Header: header,
+		}
+		
+		typeStr := ace.GetTypeString()
+		r.Equal("ACCESS_ALLOWED", typeStr)
+	})
+
+	t.Run("String returns formatted representation for BasicAce", func(t *testing.T) {
+		// Create a basic ACE
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowed,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+			Size:  20,
+		}
+		
+		accessMask := winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead | winacl.AccessMaskReadControl}
+		
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 1,
+			Authority:      []byte{0, 0, 0, 0, 0, 5},
+			SubAuthorities: []uint32{18},
+		}
+		
+		basicAce := winacl.BasicAce{SecurityIdentifier: sid}
+		
+		ace := winacl.ACE{
+			Header:     header,
+			AccessMask: accessMask,
+			ObjectAce:  basicAce,
+		}
+		
+		s := ace.String()
+		r.Contains(s, "AceType: ACCESS_ALLOWED")
+		r.Contains(s, "Flags: OBJECT_INHERIT_ACE")
+		r.Contains(s, "Permissions:")
+		r.Contains(s, "GENERIC_READ")
+		r.Contains(s, "READ_CONTROL")
+		r.Contains(s, "SID: S-1-5-18")
+	})
+	
+	t.Run("String returns formatted representation for AdvancedAce with ObjectType", func(t *testing.T) {
+		// Create an AdvancedAce with ObjectType present flag
+		guid := winacl.GUID{
+			Data1: 0x12345678,
+			Data2: 0x1234,
+			Data3: 0x5678,
+			Data4: [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		}
+		
+		ace := winacl.ACE{
+			Header: winacl.ACEHeader{
+				Type: winacl.AceTypeAccessAllowedObject,
+			},
+			AccessMask: winacl.ACEAccessMask{
+				Value: winacl.AccessMaskGenericRead,
+			},
+			ObjectAce: winacl.AdvancedAce{
+				Flags:              winacl.ACEInheritanceFlagsObjectTypePresent,
+				ObjectType:         guid,
+				SecurityIdentifier: winacl.SID{
+					Revision:       1,
+					NumAuthorities: 1,
+					Authority:      []byte{0, 0, 0, 0, 0, 5}, // NT Authority
+					SubAuthorities: []uint32{18},              // Local System
+				},
+			},
+		}
+		
+		s := ace.String()
+		r.Contains(s, "AceType: ACCESS_ALLOWED_OBJECT")
+		r.Contains(s, "ObjectType:")
+		r.Contains(s, "Permissions:")
+		r.Contains(s, "GENERIC_READ")
+		r.Contains(s, "SID: S-1-5-18")
+	})
+	
+	t.Run("String returns formatted representation for AdvancedAce with InheritedObjectType", func(t *testing.T) {
+		// Create an AdvancedAce with InheritedObjectType present flag
+		guid := winacl.GUID{
+			Data1: 0x12345678,
+			Data2: 0x1234,
+			Data3: 0x5678,
+			Data4: [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		}
+		
+		ace := winacl.ACE{
+			Header: winacl.ACEHeader{
+				Type: winacl.AceTypeAccessAllowedObject,
+			},
+			AccessMask: winacl.ACEAccessMask{
+				Value: winacl.AccessMaskGenericRead,
+			},
+			ObjectAce: winacl.AdvancedAce{
+				Flags:               winacl.ACEInheritanceFlagsInheritedObjectTypePresent,
+				InheritedObjectType: guid,
+				SecurityIdentifier:  winacl.SID{
+					Revision:       1,
+					NumAuthorities: 1,
+					Authority:      []byte{0, 0, 0, 0, 0, 5}, // NT Authority
+					SubAuthorities: []uint32{18},              // Local System
+				},
+			},
+		}
+		
+		s := ace.String()
+		r.Contains(s, "AceType: ACCESS_ALLOWED_OBJECT")
+		r.Contains(s, "InheritedObjectType:")
+		r.Contains(s, "Permissions:")
+		r.Contains(s, "GENERIC_READ")
+		r.Contains(s, "SID: S-1-5-18")
+	})
+}
+
+func TestACEHeaderFlagsString(t *testing.T) {
+	r := require.New(t)
+	header := winacl.ACEHeader{
+		Type:  winacl.AceTypeAccessAllowed,
+		Flags: winacl.ACEHeaderFlagsObjectInheritAce | winacl.ACEHeaderFlagsContainerInheritAce,
+		Size:  20,
+	}
+
+	flagsStr := header.FlagsString()
+	r.Contains(flagsStr, "OBJECT_INHERIT_ACE")
+	r.Contains(flagsStr, "CONTAINER_INHERIT_ACE")
+}
+
+func TestAdvancedAceFlagsString(t *testing.T) {
+	r := require.New(t)
+
+	aceDummy := winacl.AdvancedAce{
+		Flags: winacl.ACEInheritanceFlagsObjectTypePresent,
+	}
+
+	flagsStr := aceDummy.FlagsString()
+	r.Contains(flagsStr, "ACE_OBJECT_TYPE_PRESENT")
+}
+
+func TestNewACEHeader(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Creates an ACE header from a valid buffer", func(t *testing.T) {
+		// Prepare a buffer with valid ACE header data
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowed,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+			Size:  20,
+		}
 		buf := bytes.Buffer{}
-		err := binary.Write(&buf, binary.LittleEndian, &ace.Header)
+		err := binary.Write(&buf, binary.LittleEndian, &header)
 		r.NoError(err)
 
+		// Parse the buffer
+		parsedHeader, err := winacl.NewACEHeader(&buf)
+		r.NoError(err)
+		r.Equal(header.Type, parsedHeader.Type)
+		r.Equal(header.Flags, parsedHeader.Flags)
+		r.Equal(header.Size, parsedHeader.Size)
+	})
+
+	t.Run("Returns an error when given a malformed byte stream", func(t *testing.T) {
+		// This test may fail if newTestSD() doesn't return valid data
+		// Creating a simpler test case
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowed,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+			Size:  20,
+		}
+		buf := bytes.Buffer{}
+		err := binary.Write(&buf, binary.LittleEndian, &header)
+		r.NoError(err)
+
+		// Read one byte to make the buffer incomplete
 		buf.Next(1)
 
 		_, err = winacl.NewACEHeader(&buf)
 		r.Error(err)
 	})
-
 }

--- a/acebuilder.go
+++ b/acebuilder.go
@@ -3,92 +3,122 @@ package winacl
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 )
 
-// NewAce is a constructor that will parse out an Ace from a byte buffer
+// NewAce creates a new ACE from a byte buffer
 func NewAce(buf *bytes.Buffer) (ACE, error) {
 	ace := ACE{}
 	var err error
 
 	ace.Header, err = NewACEHeader(buf)
 	if err != nil {
-		return ace, err
+		return ace, fmt.Errorf("reading ACE header: %w", err)
 	}
-	err = binary.Read(buf, binary.LittleEndian, &ace.AccessMask.value)
+
+	err = binary.Read(buf, binary.LittleEndian, &ace.AccessMask.Value)
 	if err != nil {
-		return ace, err
+		return ace, fmt.Errorf("reading ACE access mask: %w", err)
 	}
+
+	// Process ACE based on its type
 	switch ace.Header.Type {
-	case AceTypeAccessAllowed, AceTypeAccessDenied, AceTypeSystemAudit, AceTypeSystemAlarm, AceTypeAccessAllowedCallback, AceTypeAccessDeniedCallback, AceTypeSystemAuditCallback, AceTypeSystemAlarmCallback:
+	case AceTypeAccessAllowed, AceTypeAccessDenied, AceTypeSystemAudit, AceTypeSystemAlarm, 
+	     AceTypeAccessAllowedCallback, AceTypeAccessDeniedCallback, AceTypeSystemAuditCallback, AceTypeSystemAlarmCallback:
+		
 		ace.ObjectAce, err = NewBasicAce(buf, ace.Header.Size)
 		if err != nil {
-			return ace, err
+			return ace, fmt.Errorf("parsing basic ACE: %w", err)
 		}
-	case AceTypeAccessAllowedObject, AceTypeAccessDeniedObject, AceTypeSystemAuditObject, AceTypeSystemAlarmObject, AceTypeAccessAllowedCallbackObject, AceTypeAccessDeniedCallbackObject, AceTypeSystemAuditCallbackObject, AceTypeSystemAlarmCallbackObject:
+
+	case AceTypeAccessAllowedObject, AceTypeAccessDeniedObject, AceTypeSystemAuditObject, AceTypeSystemAlarmObject, 
+	     AceTypeAccessAllowedCallbackObject, AceTypeAccessDeniedCallbackObject, AceTypeSystemAuditCallbackObject, AceTypeSystemAlarmCallbackObject:
+		
 		ace.ObjectAce, err = NewAdvancedAce(buf, ace.Header.Size)
 		if err != nil {
-			return ace, err
+			return ace, fmt.Errorf("parsing advanced ACE: %w", err)
 		}
+
+	default:
+		return ace, fmt.Errorf("unknown ACE type: %d", ace.Header.Type)
 	}
 
-	return ace, err
+	return ace, nil
 }
 
-// NewACEHeader is a constructor that will parse out an ACEHeader from a byte buffer
+// NewACEHeader creates a new ACE header from a byte buffer
 func NewACEHeader(buf *bytes.Buffer) (header ACEHeader, err error) {
-	err = binary.Read(buf, binary.LittleEndian, &header.Type)
+	// Use a single binary.Read call for the entire struct
+	err = binary.Read(buf, binary.LittleEndian, &header)
 	if err != nil {
-		return
+		return header, fmt.Errorf("reading ACE header: %w", err)
 	}
-	err = binary.Read(buf, binary.LittleEndian, &header.Flags)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &header.Size)
-	if err != nil {
-		return
-	}
-	return
+	return header, nil
 }
 
-// NewBasicAce is a constructor that will parse out an Basic from a byte buffer
+// NewBasicAce creates a new basic ACE from a byte buffer
 func NewBasicAce(buf *bytes.Buffer, totalSize uint16) (BasicAce, error) {
 	oa := BasicAce{}
-	sid, err := NewSID(buf, int(totalSize-8))
-	if err != nil {
-		return oa, err
+	
+	// Calculate remaining size for SID (total size minus header and access mask)
+	sidSize := int(totalSize) - 8
+	if sidSize <= 0 {
+		return oa, fmt.Errorf("invalid ACE size for SID: %d", sidSize)
 	}
+	
+	sid, err := NewSID(buf, sidSize)
+	if err != nil {
+		return oa, fmt.Errorf("parsing SID in basic ACE: %w", err)
+	}
+	
 	oa.SecurityIdentifier = sid
-	return oa, err
+	return oa, nil
 }
 
-// NewAdvancedAce is a constructor that will parse out an AdvancedAce from a byte buffer
+// NewAdvancedAce creates a new advanced ACE from a byte buffer
 func NewAdvancedAce(buf *bytes.Buffer, totalSize uint16) (AdvancedAce, error) {
 	oa := AdvancedAce{}
 	var err error
-	binary.Read(buf, binary.LittleEndian, &oa.Flags)
+	
+	// Read flags
+	err = binary.Read(buf, binary.LittleEndian, &oa.Flags)
+	if err != nil {
+		return oa, fmt.Errorf("reading ACE inheritance flags: %w", err)
+	}
+	
+	// Track bytes read (4 for header + 4 for access mask + 4 for flags)
 	offset := 12
-	if (oa.Flags & (ACEInheritanceFlagsObjectTypePresent)) != 0 {
+	
+	// Read object type if present
+	if (oa.Flags & ACEInheritanceFlagsObjectTypePresent) != 0 {
 		oa.ObjectType, err = NewGUID(buf)
 		if err != nil {
-			return oa, err
+			return oa, fmt.Errorf("reading object type GUID: %w", err)
 		}
 		offset += 16
 	}
 
-	if (oa.Flags & (ACEInheritanceFlagsInheritedObjectTypePresent)) != 0 {
+	// Read inherited object type if present
+	if (oa.Flags & ACEInheritanceFlagsInheritedObjectTypePresent) != 0 {
 		oa.InheritedObjectType, err = NewGUID(buf)
 		if err != nil {
-			return oa, err
+			return oa, fmt.Errorf("reading inherited object type GUID: %w", err)
 		}
 		offset += 16
 	}
 
-	// Header+AccessMask is 16 bytes, other members are 36 bytes.
-	sid, err := NewSID(buf, int(totalSize)-offset)
-	if err != nil {
-		return oa, err
+	// Calculate remaining size for SID
+	sidSize := int(totalSize) - offset
+	if sidSize <= 0 {
+		return oa, fmt.Errorf("invalid advanced ACE size for SID: %d", sidSize)
 	}
+	
+	// Read SID
+	sid, err := NewSID(buf, sidSize)
+	if err != nil {
+		return oa, fmt.Errorf("parsing SID in advanced ACE: %w", err)
+	}
+	
 	oa.SecurityIdentifier = sid
-	return oa, err
+	return oa, nil
 }

--- a/acebuilder_test.go
+++ b/acebuilder_test.go
@@ -1,0 +1,247 @@
+package winacl_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/audibleblink/go-winacl"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAce(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Creates a basic ACE from valid buffer", func(t *testing.T) {
+		// Create a buffer with a basic ACE structure
+		buf := &bytes.Buffer{}
+		
+		// Write header
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowed,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+			Size:  24, // Size needs to accommodate header + access mask + SID
+		}
+		err := binary.Write(buf, binary.LittleEndian, &header)
+		r.NoError(err)
+		
+		// Write access mask
+		accessMask := uint32(winacl.AccessMaskGenericRead | winacl.AccessMaskReadControl)
+		err = binary.Write(buf, binary.LittleEndian, accessMask)
+		r.NoError(err)
+		
+		// Write minimal SID (simplified for testing)
+		// Revision
+		err = binary.Write(buf, binary.LittleEndian, byte(1))
+		r.NoError(err)
+		// NumAuthorities
+		err = binary.Write(buf, binary.LittleEndian, byte(1))
+		r.NoError(err)
+		// Authority
+		authority := []byte{0, 0, 0, 0, 0, 5} // NT Authority
+		_, err = buf.Write(authority)
+		r.NoError(err)
+		// SubAuthority
+		subAuth := uint32(18) // Local System
+		err = binary.Write(buf, binary.LittleEndian, subAuth)
+		r.NoError(err)
+		
+		// Parse ACE
+		ace, err := winacl.NewAce(buf)
+		r.NoError(err)
+		r.Equal(winacl.AceTypeAccessAllowed, ace.Header.Type)
+		r.Equal(winacl.ACEHeaderFlagsObjectInheritAce, ace.Header.Flags)
+		r.Equal(uint32(winacl.AccessMaskGenericRead|winacl.AccessMaskReadControl), ace.AccessMask.Raw())
+		r.Equal("S-1-5-18", ace.ObjectAce.GetPrincipal().String())
+	})
+
+	t.Run("Creates an advanced ACE from valid buffer", func(t *testing.T) {
+		// Create a buffer with an advanced ACE structure
+		buf := &bytes.Buffer{}
+		
+		// Write header
+		header := winacl.ACEHeader{
+			Type:  winacl.AceTypeAccessAllowedObject,
+			Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+			Size:  48, // Size needs to be larger for object ACE
+		}
+		err := binary.Write(buf, binary.LittleEndian, &header)
+		r.NoError(err)
+		
+		// Write access mask
+		accessMask := uint32(winacl.AccessMaskGenericRead)
+		err = binary.Write(buf, binary.LittleEndian, accessMask)
+		r.NoError(err)
+		
+		// Write ACE inheritance flags
+		inheritanceFlags := uint32(winacl.ACEInheritanceFlagsObjectTypePresent)
+		err = binary.Write(buf, binary.LittleEndian, inheritanceFlags)
+		r.NoError(err)
+		
+		// Write ObjectType GUID
+		guid := winacl.GUID{
+			Data1: 0x12345678,
+			Data2: 0x1234,
+			Data3: 0x5678,
+			Data4: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		}
+		err = binary.Write(buf, binary.LittleEndian, guid)
+		r.NoError(err)
+		
+		// Write minimal SID (simplified for testing)
+		err = binary.Write(buf, binary.LittleEndian, byte(1)) // Revision
+		r.NoError(err)
+		err = binary.Write(buf, binary.LittleEndian, byte(1)) // NumAuthorities
+		r.NoError(err)
+		authority := []byte{0, 0, 0, 0, 0, 5} // NT Authority
+		_, err = buf.Write(authority)
+		r.NoError(err)
+		subAuth := uint32(18) // Local System
+		err = binary.Write(buf, binary.LittleEndian, subAuth)
+		r.NoError(err)
+		
+		// Parse ACE
+		ace, err := winacl.NewAce(buf)
+		r.NoError(err)
+		r.Equal(winacl.AceTypeAccessAllowedObject, ace.Header.Type)
+		advancedAce, ok := ace.ObjectAce.(winacl.AdvancedAce)
+		r.True(ok, "Expected AdvancedAce type")
+		r.Equal(winacl.ACEInheritanceFlagsObjectTypePresent, advancedAce.Flags)
+		r.Equal("S-1-5-18", advancedAce.SecurityIdentifier.String())
+	})
+
+	t.Run("Returns error on invalid buffer", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		// Write incomplete data
+		header := winacl.ACEHeader{
+			Type: winacl.AceTypeAccessAllowed,
+		}
+		_ = binary.Write(buf, binary.LittleEndian, &header)
+		
+		// Read one byte to make the buffer incomplete
+		buf.Next(1)
+		
+		_, err := winacl.NewAce(buf)
+		r.Error(err)
+	})
+}
+
+func TestNewBasicAce(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Creates basic ACE from valid buffer", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		
+		// Write minimal SID (simplified for testing)
+		err := binary.Write(buf, binary.LittleEndian, byte(1)) // Revision
+		r.NoError(err)
+		err = binary.Write(buf, binary.LittleEndian, byte(1)) // NumAuthorities
+		r.NoError(err)
+		authority := []byte{0, 0, 0, 0, 0, 5} // NT Authority
+		_, err = buf.Write(authority)
+		r.NoError(err)
+		subAuth := uint32(18) // Local System
+		err = binary.Write(buf, binary.LittleEndian, subAuth)
+		r.NoError(err)
+		
+		// Total size is calculated as:
+		// header (4) + access mask (4) + SID (8+4*NumAuthorities)
+		// = 8 + (8 + 4 * 1) = 8 + 12 = 20
+		basicAce, err := winacl.NewBasicAce(buf, 20)
+		r.NoError(err)
+		r.Equal("S-1-5-18", basicAce.SecurityIdentifier.String())
+	})
+
+	t.Run("Returns error on invalid buffer", func(t *testing.T) {
+		// This test is more complex because the error happens in the NewSID function
+		// which expects a certain minimum buffer size. To create a valid test case,
+		// we'll create an almost complete buffer but with data that will cause NewSID to fail
+		buf := &bytes.Buffer{}
+		
+		// Write a valid revision
+		err := binary.Write(buf, binary.LittleEndian, byte(1)) // Revision
+		r.NoError(err)
+		
+		// Write an invalid number of authorities (too large to be valid)
+		err = binary.Write(buf, binary.LittleEndian, byte(20)) // NumAuthorities (invalid value > 15)
+		r.NoError(err)
+		
+		// Write enough data to make the buffer the expected size
+		authority := []byte{0, 0, 0, 0, 0, 5} // Authority
+		_, err = buf.Write(authority)
+		r.NoError(err)
+		
+		// Since the function expects more data than available due to the large NumAuthorities,
+		// this should fail with an error
+		_, err = winacl.NewBasicAce(buf, 20)
+		r.Error(err)
+	})
+}
+
+func TestNewAdvancedAce(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Creates advanced ACE from valid buffer", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		
+		// Write inheritance flags
+		flags := uint32(winacl.ACEInheritanceFlagsObjectTypePresent)
+		err := binary.Write(buf, binary.LittleEndian, flags)
+		r.NoError(err)
+		
+		// Write ObjectType GUID
+		guid := winacl.GUID{
+			Data1: 0x12345678,
+			Data2: 0x1234,
+			Data3: 0x5678,
+			Data4: [8]byte{1, 2, 3, 4, 5, 6, 7, 8},
+		}
+		err = binary.Write(buf, binary.LittleEndian, guid)
+		r.NoError(err)
+		
+		// Write minimal SID (simplified for testing)
+		err = binary.Write(buf, binary.LittleEndian, byte(1)) // Revision
+		r.NoError(err)
+		err = binary.Write(buf, binary.LittleEndian, byte(1)) // NumAuthorities
+		r.NoError(err)
+		authority := []byte{0, 0, 0, 0, 0, 5} // NT Authority
+		_, err = buf.Write(authority)
+		r.NoError(err)
+		subAuth := uint32(18) // Local System
+		err = binary.Write(buf, binary.LittleEndian, subAuth)
+		r.NoError(err)
+		
+		// Size calculation: 
+		// header (4) + access mask (4) + flags (4) + GUID (16) + SID (8+4*NumAuthorities)
+		// = 8 + 4 + 16 + 12 = 40
+		advancedAce, err := winacl.NewAdvancedAce(buf, 40)
+		r.NoError(err)
+		r.Equal(winacl.ACEInheritanceFlagsObjectTypePresent, advancedAce.Flags)
+		r.Equal("S-1-5-18", advancedAce.SecurityIdentifier.String())
+	})
+
+	t.Run("Returns error on invalid buffer", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		
+		// Write inheritance flags
+		flags := uint32(winacl.ACEInheritanceFlagsObjectTypePresent)
+		err := binary.Write(buf, binary.LittleEndian, flags)
+		r.NoError(err)
+		
+		// Write incomplete GUID data (just enough to trigger an error but not panic)
+		// First write Data1 (uint32)
+		data1 := uint32(0x12345678)
+		err = binary.Write(buf, binary.LittleEndian, data1)
+		r.NoError(err)
+		
+		// Then a partial Data2 (uint16) to cause the error
+		data2Partial := []byte{0x12}  // Only write one byte of a uint16 to cause error
+		_, err = buf.Write(data2Partial)
+		r.NoError(err)
+		
+		// This should fail during GUID parsing
+		_, err = winacl.NewAdvancedAce(buf, 40)
+		r.Error(err)
+	})
+}

--- a/acl.go
+++ b/acl.go
@@ -3,6 +3,7 @@ package winacl
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 )
 
 // ACL represents an Access Control List
@@ -22,47 +23,33 @@ type ACLHeader struct {
 
 // NewACLHeader is a constructor that will parse out an ACLHeader from a byte buffer
 func NewACLHeader(buf *bytes.Buffer) (aclh ACLHeader, err error) {
-	err = binary.Read(buf, binary.LittleEndian, &aclh.Revision)
+	// Use a single binary.Read call for the entire struct
+	err = binary.Read(buf, binary.LittleEndian, &aclh)
 	if err != nil {
-		return
+		return aclh, fmt.Errorf("reading ACL header: %w", err)
 	}
-	err = binary.Read(buf, binary.LittleEndian, &aclh.Sbz1)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &aclh.Size)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &aclh.AceCount)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &aclh.Sbz2)
-	if err != nil {
-		return
-	}
-	return
+	return aclh, nil
 }
 
 // NewACL is a constructor that will parse out an ACL from a byte buffer
 func NewACL(buf *bytes.Buffer) (acl ACL, err error) {
 	acl.Header, err = NewACLHeader(buf)
 	if err != nil {
-		return
+		return acl, fmt.Errorf("reading ACL header: %w", err)
 	}
 
+	// Pre-allocate the slice with the exact capacity
 	acl.Aces = make([]ACE, 0, acl.Header.AceCount)
 
 	for i := 0; i < int(acl.Header.AceCount); i++ {
 		ace, err := NewAce(buf)
 		if err != nil {
-			return acl, err
+			return acl, fmt.Errorf("reading ACE %d: %w", i, err)
 		}
 		acl.Aces = append(acl.Aces, ace)
 	}
 
-	return
+	return acl, nil
 }
 
 func (header *ACLHeader) ToBuffer() (bytes.Buffer, error) {

--- a/acl_test.go
+++ b/acl_test.go
@@ -3,7 +3,7 @@ package winacl_test
 import (
 	"testing"
 
-	winacl "github.com/kgoins/go-winacl/pkg"
+	"github.com/audibleblink/go-winacl"
 	"github.com/stretchr/testify/require"
 )
 

--- a/capabilitysid.go
+++ b/capabilitysid.go
@@ -1,0 +1,198 @@
+package winacl
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// CapabilitySIDPrefix is the standard prefix for Windows Capability SIDs
+const CapabilitySIDPrefix = "S-1-15-3-"
+
+// WellKnownCapabilities maps capability names to their corresponding SID strings
+var WellKnownCapabilities = map[string]string{
+	"internetClient":                     "S-1-15-3-1",
+	"internetClientServer":               "S-1-15-3-2",
+	"privateNetworkClientServer":         "S-1-15-3-3",
+	"picturesLibrary":                    "S-1-15-3-4",
+	"videosLibrary":                      "S-1-15-3-5",
+	"musicLibrary":                       "S-1-15-3-6",
+	"documentsLibrary":                   "S-1-15-3-7",
+	"enterpriseAuthentication":           "S-1-15-3-8",
+	"sharedUserCertificates":             "S-1-15-3-9",
+	"removableStorage":                   "S-1-15-3-10",
+	"appointments":                       "S-1-15-3-11",
+	"contacts":                           "S-1-15-3-12",
+	"location":                           "S-1-15-3-1024",
+	"microphone":                         "S-1-15-3-1025",
+	"webcam":                             "S-1-15-3-1026",
+	"systemManagement":                   "S-1-15-3-1027",
+	"appCertificates":                    "S-1-15-3-1028",
+	"offlineMapsManagement":              "S-1-15-3-1029",
+	"enterpriseCloudSSO":                 "S-1-15-3-1030",
+	"remoteSystem":                       "S-1-15-3-1031",
+	"sharedUserCertificatesImport":       "S-1-15-3-1032",
+	"remoteSystemDetailedSettings":       "S-1-15-3-1033",
+	"phoneCallHistoryPublic":             "S-1-15-3-1034",
+	"spatialPerception":                  "S-1-15-3-1035",
+	"deviceUnlock":                       "S-1-15-3-1037",
+	"lowLevelDevices":                    "S-1-15-3-1038",
+	"backgroundMediaRecording":           "S-1-15-3-1039",
+	"cameraProcessingExtension":          "S-1-15-3-1040",
+	"userDataTasks":                      "S-1-15-3-1041",
+	"userActivityInactiveThresholdTimer": "S-1-15-3-1042",
+	"cellularDeviceIdentity":             "S-1-15-3-1043",
+	"cellularDeviceControl":              "S-1-15-3-1044",
+	"protectedApp":                       "S-1-15-3-1045",
+	"userDataSystem":                     "S-1-15-3-1046",
+	"graphicsCapture":                    "S-1-15-3-1047",
+	"globalMediaControl":                 "S-1-15-3-1048",
+	"appLicensing":                       "S-1-15-3-1049",
+}
+
+// Reverse map of capability SIDs to their names
+var capabilitySIDToName map[string]string
+
+func init() {
+	// Initialize the reverse map
+	capabilitySIDToName = make(map[string]string, len(WellKnownCapabilities))
+	for name, sid := range WellKnownCapabilities {
+		capabilitySIDToName[sid] = name
+	}
+}
+
+// IsCapabilitySID checks if a SID is a Windows capability SID
+func IsCapabilitySID(sid SID) bool {
+	sidStr := sid.String()
+	return strings.HasPrefix(sidStr, CapabilitySIDPrefix)
+}
+
+// CapabilityFromSID extracts the capability name from a capability SID
+func CapabilityFromSID(sid SID) (string, error) {
+	if !IsCapabilitySID(sid) {
+		return "", fmt.Errorf("not a capability SID: %s", sid.String())
+	}
+
+	sidStr := sid.String()
+	
+	// Check if it's a well-known capability
+	if name, ok := capabilitySIDToName[sidStr]; ok {
+		return name, nil
+	}
+	
+	// Return the raw capability ID for custom capabilities
+	return fmt.Sprintf("CustomCapability-%s", sidStr[len(CapabilitySIDPrefix):]), nil
+}
+
+// SIDFromCapability creates a SID from a capability name
+func SIDFromCapability(capabilityName string) (SID, error) {
+	// Check if it's a well-known capability
+	if sidStr, ok := WellKnownCapabilities[capabilityName]; ok {
+		// Parse the capability SID
+		parts := strings.Split(sidStr, "-")
+		if len(parts) < 5 {
+			return SID{}, fmt.Errorf("invalid capability SID format: %s", sidStr)
+		}
+		
+		// Create the SID
+		sid := SID{
+			Revision:       1,
+			NumAuthorities: byte(len(parts) - 3), // S-1-15-X-Y-Z has 3 authorities
+			Authority:      []byte{0, 0, 0, 0, 0, 15}, // 15 is for app package authority
+			SubAuthorities: make([]uint32, len(parts)-3),
+		}
+		
+		// Parse the sub-authorities
+		for i := 0; i < len(sid.SubAuthorities); i++ {
+			var val uint64
+			_, err := fmt.Sscanf(parts[i+3], "%d", &val)
+			if err != nil {
+				return SID{}, fmt.Errorf("invalid sub-authority in capability SID: %w", err)
+			}
+			sid.SubAuthorities[i] = uint32(val)
+		}
+		
+		return sid, nil
+	}
+	
+	// Handle custom capability format: CustomCapability-X-Y-Z
+	if strings.HasPrefix(capabilityName, "CustomCapability-") {
+		parts := strings.Split(capabilityName[17:], "-")
+		if len(parts) == 0 {
+			return SID{}, fmt.Errorf("invalid custom capability format: %s", capabilityName)
+		}
+		
+		// Create the SID
+		sid := SID{
+			Revision:       1,
+			NumAuthorities: byte(len(parts) + 1), // +1 for the "3" in S-1-15-3-...
+			Authority:      []byte{0, 0, 0, 0, 0, 15}, // 15 is for app package authority
+			SubAuthorities: make([]uint32, len(parts)+1),
+		}
+		
+		// First sub-authority is always 3 for capability SIDs
+		sid.SubAuthorities[0] = 3
+		
+		// Parse the remaining custom sub-authorities
+		for i := 0; i < len(parts); i++ {
+			var val uint64
+			_, err := fmt.Sscanf(parts[i], "%d", &val)
+			if err != nil {
+				return SID{}, fmt.Errorf("invalid sub-authority in custom capability: %w", err)
+			}
+			sid.SubAuthorities[i+1] = uint32(val)
+		}
+		
+		return sid, nil
+	}
+	
+	return SID{}, fmt.Errorf("unknown capability: %s", capabilityName)
+}
+
+// ParseCapabilitySID parses a capability SID from binary data
+func ParseCapabilitySID(data []byte) (SID, error) {
+	if len(data) < 8 {
+		return SID{}, fmt.Errorf("data too short for capability SID")
+	}
+	
+	// Verify it's a capability SID
+	revision := data[0]
+	if revision != 1 {
+		return SID{}, fmt.Errorf("invalid revision for capability SID: %d", revision)
+	}
+	
+	numAuth := data[1]
+	if numAuth < 2 {
+		return SID{}, fmt.Errorf("invalid authority count for capability SID: %d", numAuth)
+	}
+	
+	// Create a new SID
+	sid := SID{
+		Revision:       revision,
+		NumAuthorities: numAuth,
+		Authority:      make([]byte, 6),
+		SubAuthorities: make([]uint32, numAuth),
+	}
+	
+	// Copy authority (should be 15 for app containers)
+	copy(sid.Authority, data[2:8])
+	
+	// Ensure minimum length for sub-authorities
+	minLength := 8 + 4*int(numAuth)
+	if len(data) < minLength {
+		return SID{}, fmt.Errorf("data too short for capability SID with %d sub-authorities", numAuth)
+	}
+	
+	// Extract sub-authorities
+	for i := 0; i < int(numAuth); i++ {
+		offset := 8 + (i * 4)
+		sid.SubAuthorities[i] = binary.LittleEndian.Uint32(data[offset : offset+4])
+	}
+	
+	// Verify it's a capability SID
+	if sid.Authority[5] != 15 || (numAuth > 0 && sid.SubAuthorities[0] != 3) {
+		return SID{}, fmt.Errorf("not a capability SID")
+	}
+	
+	return sid, nil
+}

--- a/capabilitysid_test.go
+++ b/capabilitysid_test.go
@@ -1,0 +1,145 @@
+package winacl_test
+
+import (
+	"testing"
+
+	"github.com/audibleblink/go-winacl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCapabilitySID(t *testing.T) {
+	r := require.New(t)
+	
+	// Create a capability SID
+	capabilitySID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 2,
+		Authority:      []byte{0, 0, 0, 0, 0, 15}, // 15 is for app package authority
+		SubAuthorities: []uint32{3, 1},            // 3 is capability, 1 is internetClient
+	}
+	
+	r.True(winacl.IsCapabilitySID(capabilitySID))
+	
+	// Create a non-capability SID
+	nonCapabilitySID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5}, // 5 is NT Authority
+		SubAuthorities: []uint32{18},             // 18 is Local System
+	}
+	
+	r.False(winacl.IsCapabilitySID(nonCapabilitySID))
+}
+
+func TestCapabilityFromSID(t *testing.T) {
+	r := require.New(t)
+	
+	// Create a known capability SID (internetClient)
+	internetClientSID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 2,
+		Authority:      []byte{0, 0, 0, 0, 0, 15}, // 15 is for app package authority
+		SubAuthorities: []uint32{3, 1},            // 3 is capability, 1 is internetClient
+	}
+	
+	capability, err := winacl.CapabilityFromSID(internetClientSID)
+	r.NoError(err)
+	r.Equal("internetClient", capability)
+	
+	// Create a custom capability SID
+	customCapabilitySID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 3,
+		Authority:      []byte{0, 0, 0, 0, 0, 15}, // 15 is for app package authority
+		SubAuthorities: []uint32{3, 999, 888},     // 3 is capability, others are custom values
+	}
+	
+	customCapability, err := winacl.CapabilityFromSID(customCapabilitySID)
+	r.NoError(err)
+	r.Contains(customCapability, "CustomCapability-")
+	
+	// Test with non-capability SID
+	nonCapabilitySID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5}, // 5 is NT Authority
+		SubAuthorities: []uint32{18},             // 18 is Local System
+	}
+	
+	_, err = winacl.CapabilityFromSID(nonCapabilitySID)
+	r.Error(err)
+	r.Contains(err.Error(), "not a capability SID")
+}
+
+func TestSIDFromCapability(t *testing.T) {
+	r := require.New(t)
+	
+	// Test creating a SID from a well-known capability
+	sid, err := winacl.SIDFromCapability("internetClient")
+	r.NoError(err)
+	r.Equal(byte(1), sid.Revision)
+	r.Equal(byte(2), sid.NumAuthorities)
+	r.Equal(byte(15), sid.Authority[5])
+	r.Equal(uint32(3), sid.SubAuthorities[0])  // 3 is capability
+	r.Equal(uint32(1), sid.SubAuthorities[1])  // 1 is internetClient
+	
+	// Verify the string representation
+	r.Equal("S-1-15-3-1", sid.String())
+	
+	// Test creating a SID from a custom capability
+	customSid, err := winacl.SIDFromCapability("CustomCapability-999-888")
+	r.NoError(err)
+	r.Equal(byte(1), customSid.Revision)
+	r.Equal(byte(3), customSid.NumAuthorities)
+	r.Equal(byte(15), customSid.Authority[5])
+	r.Equal(uint32(3), customSid.SubAuthorities[0])   // 3 is capability
+	r.Equal(uint32(999), customSid.SubAuthorities[1]) // Custom value
+	r.Equal(uint32(888), customSid.SubAuthorities[2]) // Custom value
+	
+	// Test with unknown capability
+	_, err = winacl.SIDFromCapability("nonExistentCapability")
+	r.Error(err)
+	r.Contains(err.Error(), "unknown capability")
+}
+
+func TestParseCapabilitySID(t *testing.T) {
+	r := require.New(t)
+	
+	// Create binary data representing a capability SID
+	// S-1-15-3-1 (internetClient)
+	sidData := []byte{
+		1,                      // Revision
+		2,                      // NumAuthorities
+		0, 0, 0, 0, 0, 15,      // Authority (15)
+		3, 0, 0, 0,             // SubAuthority[0] = 3 (capability)
+		1, 0, 0, 0,             // SubAuthority[1] = 1 (internetClient)
+	}
+	
+	sid, err := winacl.ParseCapabilitySID(sidData)
+	r.NoError(err)
+	r.Equal(byte(1), sid.Revision)
+	r.Equal(byte(2), sid.NumAuthorities)
+	r.Equal(byte(15), sid.Authority[5])
+	r.Equal(uint32(3), sid.SubAuthorities[0])
+	r.Equal(uint32(1), sid.SubAuthorities[1])
+	r.Equal("S-1-15-3-1", sid.String())
+	
+	// Test with invalid data
+	invalidData := []byte{1, 2, 3} // Too short
+	_, err = winacl.ParseCapabilitySID(invalidData)
+	r.Error(err)
+	r.Contains(err.Error(), "data too short")
+	
+	// Test with wrong revision
+	wrongRevision := []byte{
+		2,                      // Wrong revision
+		2,                      // NumAuthorities
+		0, 0, 0, 0, 0, 15,      // Authority
+		3, 0, 0, 0,             // SubAuthority
+		1, 0, 0, 0,             // SubAuthority
+	}
+	
+	_, err = winacl.ParseCapabilitySID(wrongRevision)
+	r.Error(err)
+	r.Contains(err.Error(), "invalid revision")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,14 @@
-module github.com/kgoins/go-winacl
+module github.com/audibleblink/go-winacl
 
-go 1.16
+go 1.23
 
 require (
 	github.com/audibleblink/bamflags v1.0.0
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/audibleblink/bamflags v0.2.0 h1:xLsR8OO2mmbhpQglTvSKNJMnmQMI9L884eJ15zbu4mI=
-github.com/audibleblink/bamflags v0.2.0/go.mod h1:zpuLMpykftgB88SHYGBa1urg0uHn01R2pjeBed+JhB8=
 github.com/audibleblink/bamflags v1.0.0 h1:Ul07TOyv5Ht7/u3GsIQDUy++eiKB8q+Nvah6AgEWB8k=
 github.com/audibleblink/bamflags v1.0.0/go.mod h1:zpuLMpykftgB88SHYGBa1urg0uHn01R2pjeBed+JhB8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/guid.go
+++ b/guid.go
@@ -16,7 +16,7 @@ type GUID struct {
 
 const nullGUID = "00000000-0000-0000-0000-000000000000"
 
-// NewGUID is a constructor that will parse out a GUID from a byte buffer
+// NewGUID creates a GUID from a byte buffer
 func NewGUID(buf *bytes.Buffer) (guid GUID, err error) {
 	err = binary.Read(buf, binary.LittleEndian, &guid.Data1)
 	if err != nil {
@@ -31,6 +31,9 @@ func NewGUID(buf *bytes.Buffer) (guid GUID, err error) {
 		return
 	}
 	err = binary.Read(buf, binary.LittleEndian, &guid.Data4)
+	if err != nil {
+		return
+	}
 	return
 }
 
@@ -60,7 +63,7 @@ func (g GUID) Resolve() string {
 	return guid
 }
 
-// GUIDS is a map of all known pre-existing guids
+// GUIDS maps GUID strings to their human-readable names
 var GUIDS = map[string]string{
 	// Control Rights
 	// # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/1522b774-6464-41a3-87a5-1e5633c3fbbb

--- a/guid_test.go
+++ b/guid_test.go
@@ -2,16 +2,36 @@ package winacl_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
-	winacl "github.com/kgoins/go-winacl/pkg"
+	"github.com/audibleblink/go-winacl"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewGUID(t *testing.T) {
-
 	r := require.New(t)
+
+	t.Run("Creates a GUID from a valid buffer", func(t *testing.T) {
+		// Create a buffer with valid GUID data
+		buf := &bytes.Buffer{}
+		
+		// Write a valid GUID
+		data1 := uint32(0x12345678)
+		data2 := uint16(0x1234)
+		data3 := uint16(0x5678)
+		data4 := [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+		
+		binary.Write(buf, binary.LittleEndian, data1)
+		binary.Write(buf, binary.LittleEndian, data2)
+		binary.Write(buf, binary.LittleEndian, data3)
+		binary.Write(buf, binary.LittleEndian, data4)
+		
+		guid, err := winacl.NewGUID(buf)
+		r.NoError(err)
+		r.Equal("12345678-1234-5678-0102-030405060708", guid.String())
+	})
 
 	t.Run("Returns an error when given a malformed byte stream", func(t *testing.T) {
 		buf := &bytes.Buffer{}
@@ -19,5 +39,60 @@ func TestNewGUID(t *testing.T) {
 		_, err := winacl.NewGUID(buf)
 		r.Error(err)
 	})
+}
 
+func TestGUIDString(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Returns formatted GUID string", func(t *testing.T) {
+		guid := winacl.GUID{
+			Data1: 0x12345678,
+			Data2: 0x1234,
+			Data3: 0x5678,
+			Data4: [8]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		}
+		
+		r.Equal("12345678-1234-5678-0102-030405060708", guid.String())
+	})
+
+	t.Run("Returns empty string for null GUID", func(t *testing.T) {
+		guid := winacl.GUID{
+			Data1: 0,
+			Data2: 0,
+			Data3: 0,
+			Data4: [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
+		}
+		
+		r.Equal("", guid.String())
+	})
+}
+
+func TestGUIDResolve(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Resolves known GUID to name", func(t *testing.T) {
+		// GUID for DS-Replication-Get-Changes
+		guid := winacl.GUID{
+			Data1: 0x1131f6aa,
+			Data2: 0x9c07,
+			Data3: 0x11d1,
+			Data4: [8]byte{0xf7, 0x9f, 0x00, 0xc0, 0x4f, 0xc2, 0xdc, 0xd2},
+		}
+		
+		name := guid.Resolve()
+		r.Equal("DS-Replication-Get-Changes", name)
+	})
+
+	t.Run("Returns GUID string for unknown GUID", func(t *testing.T) {
+		// Using an unknown GUID
+		guid := winacl.GUID{
+			Data1: 0x99999999,
+			Data2: 0x9999,
+			Data3: 0x9999,
+			Data4: [8]byte{0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99},
+		}
+		
+		// Should return the GUID string itself when not known
+		r.Equal("99999999-9999-9999-9999-999999999999", guid.Resolve())
+	})
 }

--- a/integrity.go
+++ b/integrity.go
@@ -1,0 +1,131 @@
+package winacl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IntegrityLevel represents Windows integrity levels
+// See: https://docs.microsoft.com/en-us/windows/win32/secauthz/mandatory-integrity-control
+type IntegrityLevel uint32
+
+// Windows integrity level constants
+const (
+	IntegrityLevelUntrusted       IntegrityLevel = 0x0000
+	IntegrityLevelLow             IntegrityLevel = 0x1000
+	IntegrityLevelMedium          IntegrityLevel = 0x2000
+	IntegrityLevelMediumPlus      IntegrityLevel = 0x2100
+	IntegrityLevelHigh            IntegrityLevel = 0x3000
+	IntegrityLevelSystem          IntegrityLevel = 0x4000
+	IntegrityLevelProtected       IntegrityLevel = 0x5000
+	IntegrityLevelSecureProcess   IntegrityLevel = 0x6000
+)
+
+// IntegrityLevelMap maps integrity level SIDs to their IntegrityLevel values
+var IntegrityLevelMap = map[string]IntegrityLevel{
+	"S-1-16-0":      IntegrityLevelUntrusted,
+	"S-1-16-4096":   IntegrityLevelLow,
+	"S-1-16-8192":   IntegrityLevelMedium,
+	"S-1-16-8448":   IntegrityLevelMediumPlus,
+	"S-1-16-12288":  IntegrityLevelHigh,
+	"S-1-16-16384":  IntegrityLevelSystem,
+	"S-1-16-20480":  IntegrityLevelProtected,
+	"S-1-16-28672":  IntegrityLevelSecureProcess,
+}
+
+// IntegrityLevelNameMap maps IntegrityLevel values to human-readable names
+var IntegrityLevelNameMap = map[IntegrityLevel]string{
+	IntegrityLevelUntrusted:      "Untrusted",
+	IntegrityLevelLow:            "Low",
+	IntegrityLevelMedium:         "Medium",
+	IntegrityLevelMediumPlus:     "Medium Plus",
+	IntegrityLevelHigh:           "High",
+	IntegrityLevelSystem:         "System",
+	IntegrityLevelProtected:      "Protected Process",
+	IntegrityLevelSecureProcess:  "Secure Process",
+}
+
+// IntegrityLevelFromSID extracts the integrity level from a SID string
+// Windows integrity level SIDs have the format S-1-16-X
+func IntegrityLevelFromSID(sid SID) (IntegrityLevel, error) {
+	sidStr := sid.String()
+	
+	// Check if this is an integrity level SID
+	if !strings.HasPrefix(sidStr, "S-1-16-") {
+		return 0, fmt.Errorf("not an integrity level SID: %s", sidStr)
+	}
+	
+	if level, ok := IntegrityLevelMap[sidStr]; ok {
+		return level, nil
+	}
+	
+	// Try to extract the raw level value if it's not in our map
+	var rawLevel uint32
+	if len(sid.SubAuthorities) > 0 {
+		rawLevel = sid.SubAuthorities[0]
+	}
+	
+	return IntegrityLevel(rawLevel), nil
+}
+
+// String returns the human-readable name of the integrity level
+func (il IntegrityLevel) String() string {
+	if name, ok := IntegrityLevelNameMap[il]; ok {
+		return name
+	}
+	return fmt.Sprintf("Unknown (%d)", il)
+}
+
+// ToSID converts the integrity level to a SID
+func (il IntegrityLevel) ToSID() SID {
+	// Integrity level SIDs always have the format S-1-16-XXXX
+	// where XXXX is the integrity level value
+	return SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 16}, // 16 is Mandatory Label Authority
+		SubAuthorities: []uint32{uint32(il)},
+	}
+}
+
+// IsHigherThan checks if this integrity level is higher than the provided level
+func (il IntegrityLevel) IsHigherThan(other IntegrityLevel) bool {
+	return il > other
+}
+
+// IntegrityLevelPolicy defines how the integrity level check affects access
+type IntegrityLevelPolicy uint32
+
+// IntegrityLevelPolicy constants
+const (
+	PolicyNoWriteUp   IntegrityLevelPolicy = 0x1 // Prevents write access to higher integrity objects
+	PolicyNoReadUp    IntegrityLevelPolicy = 0x2 // Prevents read access to higher integrity objects
+	PolicyNoExecuteUp IntegrityLevelPolicy = 0x4 // Prevents execute access to higher integrity objects
+)
+
+// CheckAccess evaluates if a subject with this integrity level can access
+// an object with the specified integrity level given the policy
+func (il IntegrityLevel) CheckAccess(objectLevel IntegrityLevel, policy IntegrityLevelPolicy, requestedAccess uint32) bool {
+	// If subject level is higher or equal to object level, always grant access
+	if il >= objectLevel {
+		return true
+	}
+
+	// Subject level is lower than object level, apply policy
+	if (policy&PolicyNoWriteUp != 0) && 
+	   (requestedAccess&(AccessMaskGenericWrite|AccessMaskWriteDACL|AccessMaskWriteOwner) != 0) {
+		return false
+	}
+	
+	if (policy&PolicyNoReadUp != 0) && 
+	   (requestedAccess&(AccessMaskGenericRead|AccessMaskReadControl) != 0) {
+		return false
+	}
+	
+	if (policy&PolicyNoExecuteUp != 0) && 
+	   (requestedAccess&AccessMaskGenericExecute != 0) {
+		return false
+	}
+
+	return true
+}

--- a/integrity_test.go
+++ b/integrity_test.go
@@ -1,0 +1,117 @@
+package winacl_test
+
+import (
+	"testing"
+
+	"github.com/audibleblink/go-winacl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrityLevelFromSID(t *testing.T) {
+	r := require.New(t)
+	
+	// Create a Medium integrity level SID
+	mediumSID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 16}, // 16 is for Mandatory Label Authority
+		SubAuthorities: []uint32{8192},            // 8192 is Medium integrity
+	}
+	
+	level, err := winacl.IntegrityLevelFromSID(mediumSID)
+	r.NoError(err)
+	r.Equal(winacl.IntegrityLevelMedium, level)
+	r.Equal("Medium", level.String())
+	
+	// Create a SID that isn't an integrity level
+	nonIntegritySID := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5}, // 5 is NT Authority
+		SubAuthorities: []uint32{18},             // 18 is Local System
+	}
+	
+	_, err = winacl.IntegrityLevelFromSID(nonIntegritySID)
+	r.Error(err)
+	r.Contains(err.Error(), "not an integrity level SID")
+}
+
+func TestIntegrityLevelToSID(t *testing.T) {
+	r := require.New(t)
+	
+	// Test converting an integrity level to a SID
+	sid := winacl.IntegrityLevelMedium.ToSID()
+	r.Equal(byte(1), sid.Revision)
+	r.Equal(byte(1), sid.NumAuthorities)
+	r.Equal(byte(16), sid.Authority[5])
+	r.Equal(uint32(winacl.IntegrityLevelMedium), sid.SubAuthorities[0])
+	
+	// Verify the string representation
+	r.Equal("S-1-16-8192", sid.String())
+}
+
+func TestIntegrityLevelComparison(t *testing.T) {
+	r := require.New(t)
+	
+	// Test comparison between integrity levels
+	r.True(winacl.IntegrityLevelHigh.IsHigherThan(winacl.IntegrityLevelMedium))
+	r.True(winacl.IntegrityLevelMedium.IsHigherThan(winacl.IntegrityLevelLow))
+	r.False(winacl.IntegrityLevelLow.IsHigherThan(winacl.IntegrityLevelMedium))
+	r.False(winacl.IntegrityLevelMedium.IsHigherThan(winacl.IntegrityLevelMedium)) // Equal
+}
+
+func TestIntegrityLevelCheckAccess(t *testing.T) {
+	r := require.New(t)
+	
+	t.Run("NoWriteUp policy blocks write access", func(t *testing.T) {
+		// Medium user accessing High object with NoWriteUp policy
+		subjectLevel := winacl.IntegrityLevelMedium
+		objectLevel := winacl.IntegrityLevelHigh
+		policy := winacl.PolicyNoWriteUp
+		
+		// Write access should be blocked
+		r.False(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericWrite))
+		
+		// Read access should be allowed
+		r.True(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericRead))
+	})
+	
+	t.Run("NoReadUp policy blocks read access", func(t *testing.T) {
+		// Medium user accessing High object with NoReadUp policy
+		subjectLevel := winacl.IntegrityLevelMedium
+		objectLevel := winacl.IntegrityLevelHigh
+		policy := winacl.PolicyNoReadUp
+		
+		// Read access should be blocked
+		r.False(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericRead))
+		
+		// Write access should be allowed
+		r.True(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericWrite))
+	})
+	
+	t.Run("NoExecuteUp policy blocks execute access", func(t *testing.T) {
+		// Medium user accessing High object with NoExecuteUp policy
+		subjectLevel := winacl.IntegrityLevelMedium
+		objectLevel := winacl.IntegrityLevelHigh
+		policy := winacl.PolicyNoExecuteUp
+		
+		// Execute access should be blocked
+		r.False(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericExecute))
+		
+		// Read access should be allowed
+		r.True(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericRead))
+	})
+	
+	t.Run("Same or higher integrity always allows access", func(t *testing.T) {
+		// High user accessing Medium object
+		subjectLevel := winacl.IntegrityLevelHigh
+		objectLevel := winacl.IntegrityLevelMedium
+		policy := winacl.PolicyNoWriteUp | winacl.PolicyNoReadUp | winacl.PolicyNoExecuteUp
+		
+		// All access should be allowed
+		r.True(subjectLevel.CheckAccess(objectLevel, policy, winacl.AccessMaskGenericAll))
+		
+		// Equal integrity should also allow access
+		r.True(winacl.IntegrityLevelMedium.CheckAccess(winacl.IntegrityLevelMedium, policy, winacl.AccessMaskGenericAll))
+	})
+}

--- a/ntsd_test.go
+++ b/ntsd_test.go
@@ -3,12 +3,12 @@ package winacl_test
 import (
 	"testing"
 
-	winacl "github.com/kgoins/go-winacl/pkg"
 	"github.com/stretchr/testify/require"
+
+	"github.com/audibleblink/go-winacl"
 )
 
 func TestNewNtSecurityDescriptor(t *testing.T) {
-
 	r := require.New(t)
 
 	t.Run("Creates a new Security Descriptor from a byte slice", func(t *testing.T) {
@@ -28,7 +28,22 @@ func TestNewNtSecurityDescriptor(t *testing.T) {
 		_, err := winacl.NewNtSecurityDescriptor(ntsdBytes)
 		r.Error(err)
 	})
+}
 
+func TestNtSecurityDescriptorString(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Returns formatted string representation", func(t *testing.T) {
+		ntsd := newTestSD()
+		
+		result := ntsd.String()
+		r.Contains(result, "Parsed Security Descriptor:")
+		r.Contains(result, "Offsets:")
+		r.Contains(result, "Owner=")
+		r.Contains(result, "Group=")
+		r.Contains(result, "Sacl=")
+		r.Contains(result, "Dacl=")
+	})
 }
 
 func TestToSDDL(t *testing.T) {
@@ -39,7 +54,3 @@ func TestToSDDL(t *testing.T) {
 		r.Equal(sddl, ntsd.ToSDDL())
 	})
 }
-
-// t.Run("",func(t *testing.T){
-//
-// })

--- a/ntsdheader.go
+++ b/ntsdheader.go
@@ -3,6 +3,7 @@ package winacl
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 )
 
 // NtSecurityDescriptorHeader is the Header of a Security Descriptor
@@ -26,33 +27,10 @@ const (
 // NewNTSDHeader is a constructor that will parse out an
 // NtSecurityDescriptorHeader from a byte buffer
 func NewNTSDHeader(buf *bytes.Buffer) (header NtSecurityDescriptorHeader, err error) {
-	err = binary.Read(buf, binary.LittleEndian, &header.Revision)
+	// Use a single binary.Read call for the entire struct
+	err = binary.Read(buf, binary.LittleEndian, &header)
 	if err != nil {
-		return
+		return header, fmt.Errorf("reading NTSD header: %w", err)
 	}
-	err = binary.Read(buf, binary.LittleEndian, &header.Sbz1)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &header.Control)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &header.OffsetOwner)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &header.OffsetGroup)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &header.OffsetSacl)
-	if err != nil {
-		return
-	}
-	err = binary.Read(buf, binary.LittleEndian, &header.OffsetDacl)
-	if err != nil {
-		return
-	}
-	return
+	return header, nil
 }

--- a/sddl.go
+++ b/sddl.go
@@ -152,7 +152,7 @@ var WellKnownSIDsSSDL = map[string]string{
 // in SDDL format
 func (s ACE) RightsString() string {
 	sb := strings.Builder{}
-	flags, _ := bamflags.ParseInt(int64(s.AccessMask.value))
+	flags, _ := bamflags.ParseInt(int64(s.AccessMask.Value))
 
 	for _, flag := range flags {
 		symbol := AceRightsSDDL[uint32(flag)]
@@ -176,7 +176,7 @@ func (s ACEHeader) SDDLFlags() string {
 // ToSDDL will convert the individual components of an ACD
 // into an SDDL compliant string
 //
-//https://docs.microsoft.com/en-us/windows/win32/secauthz/ace-strings
+// https://docs.microsoft.com/en-us/windows/win32/secauthz/ace-strings
 func (s ACE) ToSDDL() string {
 	format := "(%s;%s;%s;%s;%s;%s)"
 

--- a/sddl_test.go
+++ b/sddl_test.go
@@ -1,0 +1,205 @@
+package winacl_test
+
+import (
+	"testing"
+
+	"github.com/audibleblink/go-winacl"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestACERightsString(t *testing.T) {
+	r := require.New(t)
+
+	// Create an ACE with specific permissions
+	ace := winacl.ACE{
+		AccessMask: winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead | winacl.AccessMaskReadControl},
+	}
+
+	// Test RightsString method
+	s := ace.RightsString()
+	r.Contains(s, "GR") // Generic Read
+	r.Contains(s, "RC") // Read Control
+}
+
+func TestACEHeaderSDDLFlags(t *testing.T) {
+	r := require.New(t)
+
+	// Create an ACE header with specific flags
+	header := winacl.ACEHeader{
+		Flags: winacl.ACEHeaderFlagsObjectInheritAce | winacl.ACEHeaderFlagsContainerInheritAce,
+	}
+
+	// Test SDDLFlags method
+	s := header.SDDLFlags()
+	r.Contains(s, "OI") // Object Inherit
+	r.Contains(s, "CI") // Container Inherit
+}
+
+func TestACEToSDDL(t *testing.T) {
+	r := require.New(t)
+	
+	// Create a basic ACE since the test data might not be available
+	header := winacl.ACEHeader{
+		Type:  winacl.AceTypeAccessAllowed,
+		Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+		Size:  20,
+	}
+	
+	accessMask := winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead}
+	
+	sid := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5},
+		SubAuthorities: []uint32{18},
+	}
+	
+	basicAce := winacl.BasicAce{SecurityIdentifier: sid}
+	
+	ace := winacl.ACE{
+		Header:     header,
+		AccessMask: accessMask,
+		ObjectAce:  basicAce,
+	}
+
+	// Test ToSDDL method
+	sddl := ace.ToSDDL()
+	r.Contains(sddl, "(")
+	r.Contains(sddl, ";")
+	r.Contains(sddl, ")")
+	// Expect SDDL format: (AceType;AceFlags;Rights;ObjectGUID;InheritedObjectGUID;AccountSID)
+	r.Regexp(`\([A-Z]+;[A-Z]*;[A-Z]*;[^;]*;[^;]*;[^;)]*\)`, sddl)
+}
+
+func TestACLToSDDL(t *testing.T) {
+	r := require.New(t)
+	
+	// Create an ACL with a basic ACE
+	header := winacl.ACEHeader{
+		Type:  winacl.AceTypeAccessAllowed,
+		Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+		Size:  20,
+	}
+	
+	accessMask := winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead}
+	
+	sid := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5},
+		SubAuthorities: []uint32{18},
+	}
+	
+	basicAce := winacl.BasicAce{SecurityIdentifier: sid}
+	
+	ace := winacl.ACE{
+		Header:     header,
+		AccessMask: accessMask,
+		ObjectAce:  basicAce,
+	}
+	
+	aclHeader := winacl.ACLHeader{
+		Revision: 1,
+		AceCount: 1,
+		Size: 20,
+	}
+	
+	acl := winacl.ACL{
+		Header: aclHeader,
+		Aces: []winacl.ACE{ace},
+	}
+
+	// Test ToSDDL method with empty flags
+	sddl := acl.ToSDDL("")
+	r.Contains(sddl, "D:")
+	r.Contains(sddl, "(") // Contains at least one ACE
+
+	// Test ToSDDL method with flags
+	sddl = acl.ToSDDL("P")
+	r.Contains(sddl, "D:P")
+}
+
+func TestNtSecurityDescriptorHeaderToSDDL(t *testing.T) {
+	r := require.New(t)
+
+	// Create a header with specific control flags
+	header := winacl.NtSecurityDescriptorHeader{
+		Control: uint16(winacl.ControlDACLProtected | winacl.ControlDACLAutoInherit),
+	}
+
+	// Test ToSDDL method
+	sddl := header.ToSDDL()
+	r.Contains(sddl, "P")  // Protected
+	r.Contains(sddl, "AI") // Auto Inherit
+}
+
+func TestNtSecurityDescriptorToSDDL(t *testing.T) {
+	r := require.New(t)
+	
+	// Create a security descriptor
+	header := winacl.NtSecurityDescriptorHeader{
+		Revision: 1,
+		Control: uint16(winacl.ControlDACLProtected),
+		OffsetOwner: 20,
+		OffsetGroup: 40,
+	}
+	
+	// Create owner SID
+	ownerSid := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5},
+		SubAuthorities: []uint32{18},
+	}
+	
+	// Create group SID
+	groupSid := winacl.SID{
+		Revision:       1,
+		NumAuthorities: 1,
+		Authority:      []byte{0, 0, 0, 0, 0, 5},
+		SubAuthorities: []uint32{32},
+	}
+	
+	// Create an ACE for DACL
+	aceHeader := winacl.ACEHeader{
+		Type:  winacl.AceTypeAccessAllowed,
+		Flags: winacl.ACEHeaderFlagsObjectInheritAce,
+		Size:  20,
+	}
+	
+	accessMask := winacl.ACEAccessMask{Value: winacl.AccessMaskGenericRead}
+	basicAce := winacl.BasicAce{SecurityIdentifier: ownerSid}
+	
+	ace := winacl.ACE{
+		Header:     aceHeader,
+		AccessMask: accessMask,
+		ObjectAce:  basicAce,
+	}
+	
+	// Create ACL
+	aclHeader := winacl.ACLHeader{
+		Revision: 1,
+		AceCount: 1,
+		Size: 20,
+	}
+	
+	acl := winacl.ACL{
+		Header: aclHeader,
+		Aces: []winacl.ACE{ace},
+	}
+	
+	// Create security descriptor
+	sd := winacl.NtSecurityDescriptor{
+		Header: header,
+		Owner: ownerSid,
+		Group: groupSid,
+		DACL: acl,
+	}
+
+	// Test ToSDDL method
+	sddl := sd.ToSDDL()
+	r.Contains(sddl, "O:")  // Owner
+	r.Contains(sddl, "G:")  // Group
+	r.Contains(sddl, "D:")  // DACL
+}

--- a/sddlbuilder.go
+++ b/sddlbuilder.go
@@ -1,0 +1,290 @@
+package winacl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SDDLBuilder provides a fluent API for constructing Security Descriptor Definition Language strings
+type SDDLBuilder struct {
+	owner     string // SID or special name
+	group     string // SID or special name
+	dacl      []string // ACE strings
+	sacl      []string // ACE strings
+	flags     uint16 // Security descriptor control flags
+	useOwner  bool
+	useGroup  bool
+	useDacl   bool
+	useSacl   bool
+	useFlags  bool
+}
+
+// NewSDDLBuilder creates a new SDDL builder instance
+func NewSDDLBuilder() *SDDLBuilder {
+	return &SDDLBuilder{
+		dacl: make([]string, 0),
+		sacl: make([]string, 0),
+	}
+}
+
+// WithOwner sets the owner SID in the security descriptor
+func (sb *SDDLBuilder) WithOwner(sid string) *SDDLBuilder {
+	sb.owner = sid
+	sb.useOwner = true
+	return sb
+}
+
+// WithOwnerSID sets the owner SID in the security descriptor using a SID object
+func (sb *SDDLBuilder) WithOwnerSID(sid SID) *SDDLBuilder {
+	return sb.WithOwner(sid.String())
+}
+
+// WithGroup sets the group SID in the security descriptor
+func (sb *SDDLBuilder) WithGroup(sid string) *SDDLBuilder {
+	sb.group = sid
+	sb.useGroup = true
+	return sb
+}
+
+// WithGroupSID sets the group SID in the security descriptor using a SID object
+func (sb *SDDLBuilder) WithGroupSID(sid SID) *SDDLBuilder {
+	return sb.WithGroup(sid.String())
+}
+
+// WithFlags sets the security descriptor control flags
+func (sb *SDDLBuilder) WithFlags(flags uint16) *SDDLBuilder {
+	sb.flags = flags
+	sb.useFlags = true
+	return sb
+}
+
+// formatACL formats an ACL string from a slice of ACE strings
+func (sb *SDDLBuilder) formatACL(aces []string) string {
+	return strings.Join(aces, "")
+}
+
+// WithFlag adds a specific flag to the security descriptor
+// Valid flags are: P (Protected), AI (Auto-Inherited), AR (Auto Inherit Required), etc.
+func (sb *SDDLBuilder) WithFlag(flag string) *SDDLBuilder {
+	// Define known flags
+	flagMap := map[string]uint16{
+		"P":   DACLProtected,
+		"AR":  DACLAutoInheritReq,
+		"AI":  DACLAutoInherited,
+		"SA":  SACLAutoInherited,
+		"SR":  0x0200, // SACL Auto Inherit Req
+		"SP":  0x2000, // SACL Protected
+		"NO":  0x0100, // No Owner propagate
+		"NG":  0x0200, // No Group propagate
+		"SD":  0x0001, // Self-relative
+		"DT":  0x0008, // DACL Trusted
+		"SS":  0x0008, // SACL Trusted
+		"RM":  0x2000, // RM Control Valid
+		"CR":  0x0010, // Create Revision
+		"CO":  0x0004, // Control Access
+		"SR1": 0x0800, // Server Security
+	}
+
+	if val, ok := flagMap[flag]; ok {
+		sb.flags |= val
+		sb.useFlags = true
+	}
+	
+	return sb
+}
+
+// WithDACL adds a DACL to the security descriptor
+func (sb *SDDLBuilder) WithDACL() *SDDLBuilder {
+	sb.useDacl = true
+	return sb
+}
+
+// WithSACL adds a SACL to the security descriptor
+func (sb *SDDLBuilder) WithSACL() *SDDLBuilder {
+	sb.useSacl = true
+	return sb
+}
+
+// AccessAllowedACE adds an Access Allowed ACE to the DACL
+func (sb *SDDLBuilder) AccessAllowedACE(sid string, accessMask uint32, flags byte) *SDDLBuilder {
+	sb.useDacl = true
+	aceString := fmt.Sprintf("(A;%s;%s;;;%s)", formatACEFlags(flags), formatAccessMask(accessMask), sid)
+	sb.dacl = append(sb.dacl, aceString)
+	return sb
+}
+
+// AccessDeniedACE adds an Access Denied ACE to the DACL
+func (sb *SDDLBuilder) AccessDeniedACE(sid string, accessMask uint32, flags byte) *SDDLBuilder {
+	sb.useDacl = true
+	aceString := fmt.Sprintf("(D;%s;%s;;;%s)", formatACEFlags(flags), formatAccessMask(accessMask), sid)
+	sb.dacl = append(sb.dacl, aceString)
+	return sb
+}
+
+// AuditACE adds an Audit ACE to the SACL
+func (sb *SDDLBuilder) AuditACE(sid string, accessMask uint32, flags byte, success, failure bool) *SDDLBuilder {
+	sb.useSacl = true
+	
+	auditType := ""
+	if success && failure {
+		auditType = "AU"
+	} else if success {
+		auditType = "SA"
+	} else if failure {
+		auditType = "FA"
+	}
+	
+	aceString := fmt.Sprintf("(%s;%s;%s;;;%s)", auditType, formatACEFlags(flags), formatAccessMask(accessMask), sid)
+	sb.sacl = append(sb.sacl, aceString)
+	return sb
+}
+
+// formatACEFlags converts ACE header flags to SDDL format
+func formatACEFlags(flags byte) string {
+	result := ""
+	
+	// Map flags to SDDL characters
+	flagMap := map[byte]string{
+		byte(ACEHeaderFlagsObjectInheritAce):        "OI",
+		byte(ACEHeaderFlagsContainerInheritAce):     "CI",
+		byte(ACEHeaderFlagsNoPropogateInheritAce):   "NP",
+		byte(ACEHeaderFlagsInheritOnlyAce):          "IO",
+		byte(ACEHeaderFlagsInheritedAce):            "ID",
+		byte(ACEHeaderFlagsSuccessfulAccessAceFlag): "SA",
+		byte(ACEHeaderFlagsFailedAccessAceFlag):     "FA",
+	}
+	
+	for mask, flag := range flagMap {
+		if flags&mask != 0 {
+			result += flag
+		}
+	}
+	
+	return result
+}
+
+// formatAccessMask converts an access mask to SDDL format
+func formatAccessMask(mask uint32) string {
+	// Try using basic rights first
+	basic := formatBasicAccessMask(mask)
+	if basic != "" {
+		return basic
+	}
+	
+	// Otherwise, use hex format
+	return fmt.Sprintf("0x%08X", mask)
+}
+
+// formatBasicAccessMask tries to format using well-known rights
+func formatBasicAccessMask(mask uint32) string {
+	// Map of standard access rights
+	rightsMap := map[uint32]string{
+		AccessMaskGenericAll:     "GA",
+		AccessMaskGenericExecute: "GX",
+		AccessMaskGenericWrite:   "GW",
+		AccessMaskGenericRead:    "GR",
+		AccessMaskMaximumAllowed: "MA",
+		AccessMaskReadControl:    "RC",
+		AccessMaskWriteDACL:      "WD",
+		AccessMaskWriteOwner:     "WO",
+		AccessMaskDelete:         "SD",
+		AccessMaskSynchronize:    "SY",
+	}
+	
+	// Check if exact well-known mask
+	for right, code := range rightsMap {
+		if mask == right {
+			return code
+		}
+	}
+	
+	// Look for combination of rights
+	result := ""
+	for right, code := range rightsMap {
+		if mask&right != 0 {
+			result += code
+		}
+	}
+	
+	return result
+}
+
+// Build constructs the SDDL string
+func (sb *SDDLBuilder) Build() string {
+	var parts []string
+	
+	// Add owner if present
+	if sb.useOwner {
+		parts = append(parts, fmt.Sprintf("O:%s", sb.owner))
+	}
+	
+	// Add group if present
+	if sb.useGroup {
+		parts = append(parts, fmt.Sprintf("G:%s", sb.group))
+	}
+	
+	// Add DACL with flags if present
+	if sb.useDacl {
+		// Start with "D:"
+		daclPart := "D:"
+		
+		// Add flags if present
+		if sb.useFlags {
+			daclPart += formatSDFlags(sb.flags)
+		}
+		
+		// Add ACEs
+		if len(sb.dacl) > 0 {
+			daclPart += sb.formatACL(sb.dacl)
+		}
+		
+		parts = append(parts, daclPart)
+	} else if sb.useFlags {
+		// If we have flags but no DACL, add them to their own part
+		parts = append(parts, fmt.Sprintf("D:%s", formatSDFlags(sb.flags)))
+	}
+	
+	// Add SACL if present
+	if sb.useSacl {
+		if len(sb.sacl) > 0 {
+			parts = append(parts, fmt.Sprintf("S:%s", sb.formatACL(sb.sacl)))
+		} else {
+			parts = append(parts, "S:") // Empty SACL
+		}
+	}
+	
+	return strings.Join(parts, "")
+}
+
+// formatSDFlags formats security descriptor flags for SDDL
+func formatSDFlags(flags uint16) string {
+	result := ""
+	
+	// Map of flags to SDDL codes
+	flagMap := map[uint16]string{
+		DACLProtected:     "P",
+		DACLAutoInheritReq: "AR",
+		DACLAutoInherited: "AI",
+		SACLAutoInherited: "SA",
+		0x0200:            "SR", // SACL Auto Inherit Req
+		0x2000:            "SP", // SACL Protected
+	}
+	
+	for flag, code := range flagMap {
+		if flags&flag != 0 {
+			result += code
+		}
+	}
+	
+	return result
+}
+
+// Parse parses an SDDL string into a security descriptor
+func (sb *SDDLBuilder) Parse(sddl string) (*NtSecurityDescriptor, error) {
+	// This is a placeholder - implementing a full SDDL parser would be quite involved
+	// and would duplicate functionality that might already exist elsewhere in the library
+	// We'd need to integrate with existing parsing logic in the library
+	
+	// Placeholder error for now
+	return nil, fmt.Errorf("SDDL parsing not implemented in the builder yet")
+}

--- a/sddlbuilder_test.go
+++ b/sddlbuilder_test.go
@@ -1,0 +1,121 @@
+package winacl_test
+
+import (
+	"testing"
+
+	"github.com/audibleblink/go-winacl"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSDDLBuilder(t *testing.T) {
+	r := require.New(t)
+	
+	t.Run("Build simple SDDL with owner", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add an owner (local system)
+		sddl := builder.WithOwner("S-1-5-18").Build()
+		
+		r.Equal("O:S-1-5-18", sddl)
+	})
+	
+	t.Run("Build SDDL with owner and group", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add owner and group
+		sddl := builder.
+			WithOwner("S-1-5-18").
+			WithGroup("S-1-5-32-544"). // BUILTIN\Administrators
+			Build()
+		
+		r.Equal("O:S-1-5-18G:S-1-5-32-544", sddl)
+	})
+	
+	t.Run("Build SDDL with DACL", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add owner, group, and DACL with allow ACE
+		sddl := builder.
+			WithOwner("S-1-5-18").
+			WithGroup("S-1-5-32-544").
+			WithDACL().
+			AccessAllowedACE("S-1-1-0", winacl.AccessMaskGenericRead, byte(winacl.ACEHeaderFlagsObjectInheritAce)).
+			Build()
+		
+		r.Equal("O:S-1-5-18G:S-1-5-32-544D:(A;OI;GR;;;S-1-1-0)", sddl)
+	})
+	
+	t.Run("Build SDDL with multiple ACEs", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add owner, group, and DACL with multiple ACEs
+		sddl := builder.
+			WithOwner("S-1-5-18").
+			WithGroup("S-1-5-32-544").
+			WithDACL().
+			AccessAllowedACE("S-1-1-0", winacl.AccessMaskGenericRead, byte(winacl.ACEHeaderFlagsObjectInheritAce)).
+			AccessDeniedACE("S-1-5-7", winacl.AccessMaskGenericWrite, byte(0)). // Anonymous
+			Build()
+		
+		r.Equal("O:S-1-5-18G:S-1-5-32-544D:(A;OI;GR;;;S-1-1-0)(D;;GW;;;S-1-5-7)", sddl)
+	})
+	
+	t.Run("Build SDDL with flags", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add DACL with protected flag (P)
+		sddl := builder.
+			WithOwner("S-1-5-18").
+			WithFlag("P"). // Protected
+			WithDACL().
+			AccessAllowedACE("S-1-1-0", winacl.AccessMaskGenericRead, byte(0)).
+			Build()
+		
+		r.Equal("O:S-1-5-18D:P(A;;GR;;;S-1-1-0)", sddl)
+	})
+	
+	t.Run("Build SDDL with SACL for auditing", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add SACL with audit ACE
+		sddl := builder.
+			WithOwner("S-1-5-18").
+			WithSACL().
+			AuditACE("S-1-1-0", winacl.AccessMaskGenericAll, byte(0), true, true). // Success and failure
+			Build()
+		
+		r.Equal("O:S-1-5-18S:(AU;;GA;;;S-1-1-0)", sddl)
+	})
+	
+	t.Run("Build SDDL with empty ACLs", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Add empty DACL and SACL
+		sddl := builder.
+			WithOwner("S-1-5-18").
+			WithDACL().
+			WithSACL().
+			Build()
+		
+		r.Equal("O:S-1-5-18D:S:", sddl)
+	})
+	
+	t.Run("Build SDDL with Owner SID", func(t *testing.T) {
+		builder := winacl.NewSDDLBuilder()
+		
+		// Create a SID for Local System
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 1,
+			Authority:      []byte{0, 0, 0, 0, 0, 5}, // NT Authority
+			SubAuthorities: []uint32{18},             // Local System
+		}
+		
+		// Use the SID object directly
+		sddl := builder.
+			WithOwnerSID(sid).
+			Build()
+		
+		r.Equal("O:S-1-5-18", sddl)
+	})
+}

--- a/sid_test.go
+++ b/sid_test.go
@@ -2,16 +2,46 @@ package winacl_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
-	winacl "github.com/kgoins/go-winacl/pkg"
+	"github.com/audibleblink/go-winacl"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewSID(t *testing.T) {
-
 	r := require.New(t)
+
+	t.Run("Creates a SID from a valid buffer", func(t *testing.T) {
+		// Create a buffer with a valid SID
+		buf := &bytes.Buffer{}
+		
+		// Revision (byte)
+		buf.WriteByte(1)
+		
+		// NumAuthorities (byte)
+		buf.WriteByte(1)
+		
+		// Authority (6 bytes)
+		authority := []byte{0, 0, 0, 0, 0, 5} // NT Authority
+		buf.Write(authority)
+		
+		// SubAuthority (4 bytes per NumAuthorities)
+		subAuth := uint32(18) // Local System
+		binary.Write(buf, binary.LittleEndian, subAuth)
+		
+		// Create SID
+		sid, err := winacl.NewSID(buf, buf.Len())
+		r.NoError(err)
+		r.Equal("S-1-5-18", sid.String())
+	})
+
+	t.Run("Returns an error for too small buffer", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		_, err := winacl.NewSID(buf, 4)
+		r.IsType(winacl.SIDInvalidError{}, err)
+	})
 
 	t.Run("Returns an error when given a malformed byte stream", func(t *testing.T) {
 		buf := &bytes.Buffer{}
@@ -19,5 +49,113 @@ func TestNewSID(t *testing.T) {
 		_, err := winacl.NewSID(buf, 4)
 		r.IsType(winacl.SIDInvalidError{}, err)
 	})
+	
+	t.Run("Returns an error for invalid revision", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		
+		// Invalid revision
+		buf.WriteByte(2)
+		
+		// NumAuthorities
+		buf.WriteByte(1)
+		
+		// Authority
+		authority := []byte{0, 0, 0, 0, 0, 5}
+		buf.Write(authority)
+		
+		// SubAuthority
+		subAuth := uint32(18)
+		binary.Write(buf, binary.LittleEndian, subAuth)
+		
+		_, err := winacl.NewSID(buf, buf.Len())
+		r.IsType(winacl.SIDInvalidError{}, err)
+	})
+	
+	t.Run("Returns an error for too many subauthorities", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		
+		// Revision
+		buf.WriteByte(1)
+		
+		// Too many NumAuthorities
+		buf.WriteByte(20) // > 15 is invalid
+		
+		// Authority
+		authority := []byte{0, 0, 0, 0, 0, 5}
+		buf.Write(authority)
+		
+		// Not writing subauthorities since we'll fail on the check
+		
+		_, err := winacl.NewSID(buf, buf.Len())
+		r.IsType(winacl.SIDInvalidError{}, err)
+	})
+}
 
+func TestSIDString(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Returns properly formatted SID string", func(t *testing.T) {
+		// Create a SID manually
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 1,
+			Authority:      []byte{0, 0, 0, 0, 0, 5},
+			SubAuthorities: []uint32{18},
+		}
+		
+		r.Equal("S-1-5-18", sid.String())
+	})
+	
+	t.Run("Returns empty string for invalid authority length", func(t *testing.T) {
+		// Create a SID with invalid authority length
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 1,
+			Authority:      []byte{0, 0, 0}, // Too short
+			SubAuthorities: []uint32{18},
+		}
+		
+		r.Equal("", sid.String())
+	})
+}
+
+func TestSIDResolve(t *testing.T) {
+	r := require.New(t)
+
+	t.Run("Resolves known SID to name", func(t *testing.T) {
+		// Create a SID for Local System (S-1-5-18)
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 1,
+			Authority:      []byte{0, 0, 0, 0, 0, 5},
+			SubAuthorities: []uint32{18},
+		}
+		
+		r.Equal("Local System", sid.Resolve())
+	})
+	
+	t.Run("Resolves SID using regex pattern", func(t *testing.T) {
+		// Create a SID for a domain admin (S-1-5-21-x-y-z-500)
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 5,
+			Authority:      []byte{0, 0, 0, 0, 0, 5},
+			SubAuthorities: []uint32{21, 1000, 2000, 3000, 500},
+		}
+		
+		r.Equal("Administrator", sid.Resolve())
+	})
+	
+	t.Run("Returns SID string for unknown SID", func(t *testing.T) {
+		// Create a SID with values that won't match anything
+		sid := winacl.SID{
+			Revision:       1,
+			NumAuthorities: 2,
+			Authority:      []byte{0, 0, 0, 0, 0, 9}, // Using 9 instead of typical values
+			SubAuthorities: []uint32{999, 999},
+		}
+		
+		sidString := sid.String()
+		r.Equal(sidString, sid.Resolve())
+	})
 }

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	winacl "github.com/kgoins/go-winacl/pkg"
+	"github.com/audibleblink/go-winacl"
 )
 
 func getTestDataDir() string {
-	return "../testdata"
+	return "./testdata"
 }
 
 func getTestNtsdBytes() ([]byte, error) {


### PR DESCRIPTION
  This commit adds several new features to the Windows ACL modeling:
  - AccessCheck implementation to simulate Windows access control decisions
  - Integrity level support with policy-based enforcement
  - Generic rights mapping between Windows access masks
  - Capability SID support for Windows 8+ app containers
  - SDDL builder with fluent API for creating security descriptors
  - Comprehensive test coverage for all new functionality